### PR TITLE
[Update] Item & Gimmick System Update

### DIFF
--- a/Config/DefaultGame.ini
+++ b/Config/DefaultGame.ini
@@ -112,8 +112,7 @@ bSkipMovies=False
 +IniSectionDenylist=StorageServers
 +IniSectionDenylist=/Script/AndroidFileServerEditor.AndroidFileServerRuntimeSettings
 +DirectoriesToAlwaysCook=(Path="/NNEDenoiser")
-+DirectoriesToAlwaysCook=(Path="/Game/GimmickTest")
-+DirectoriesToAlwaysCook=(Path="/Game/GimmickTest/Data")
++DirectoriesToAlwaysCook=(Path="/Game/CR4S/_Data")
 bRetainStagedDirectory=False
 CustomStageCopyHandler=
 

--- a/Content/CR4S/_Art/Material/Gimmick/MI_GimmickHighlight.uasset
+++ b/Content/CR4S/_Art/Material/Gimmick/MI_GimmickHighlight.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7a01ccef92bb10d9ff492eeb0228852c2414649b26900c4456aee5a5b7b1c2fb
+size 7378

--- a/Content/CR4S/_Art/Material/Gimmick/M_GimmickHighlight.uasset
+++ b/Content/CR4S/_Art/Material/Gimmick/M_GimmickHighlight.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c6cadb31a86a6a147b2bfe6ab8c91a7f242d8d7dba7dbdca380505c8a582b8a9
+size 21719

--- a/Content/CR4S/_Art/TestMap.umap
+++ b/Content/CR4S/_Art/TestMap.umap
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:17fb6723b84662f6fe2f1fae5c685db14fc36a10fd9be9faca67b1fb1b173df7
-size 1461

--- a/Content/CR4S/_Blueprint/Gimmick/Buildings/BP_Door.uasset
+++ b/Content/CR4S/_Blueprint/Gimmick/Buildings/BP_Door.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8baf20da56c44808a84b17ba34d5e230bda9de0a31317b5a51b3146939db7104
+size 33295

--- a/Content/CR4S/_Blueprint/Gimmick/MI_Cube_01.uasset
+++ b/Content/CR4S/_Blueprint/Gimmick/MI_Cube_01.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:72d85d6a37f78c266eb0377c2def3a9879852d3b70514d72faabea1b4589cacb
+size 10510

--- a/Content/CR4S/_Blueprint/Gimmick/ResourceGimmicks/BP_Tree.uasset
+++ b/Content/CR4S/_Blueprint/Gimmick/ResourceGimmicks/BP_Tree.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b189c8b6e6e362ecb47ccddb39fc30f617d29332dc897477c867a571f50b4912
+size 33069

--- a/Content/CR4S/_Blueprint/Gimmick/ResourceGimmicks/SM_Cube_01_SM_Cube_01/GC_SM_Cube_01.uasset
+++ b/Content/CR4S/_Blueprint/Gimmick/ResourceGimmicks/SM_Cube_01_SM_Cube_01/GC_SM_Cube_01.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eea84862bcab0c323fd3641f41eedbf1465ff11d79904a21b977da931cff42a7
+size 923742

--- a/Content/CR4S/_Blueprint/Gimmick/SM_Cube_01.uasset
+++ b/Content/CR4S/_Blueprint/Gimmick/SM_Cube_01.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:66ee5263984a902be1810f3a403f9f2ea9ca097669387eb6212851b7ab2c533c
+size 60174

--- a/Content/CR4S/_Blueprint/UI/Gimmick/WBP_Interaction.uasset
+++ b/Content/CR4S/_Blueprint/UI/Gimmick/WBP_Interaction.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4729f13e96da414f4d41d482436c4219e128a01654834096e448ae9afe25ec28
+size 29080

--- a/Content/CR4S/_Data/Item/DT_GimmickData.uasset
+++ b/Content/CR4S/_Data/Item/DT_GimmickData.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f9300607d439c777876e41b0890f3fe9da58a7f0ce845471192426c25044f928
-size 3348
+oid sha256:92c42bb21530155b7bc11e9e0d28f1acf06c85a6fcb82a15219753fac0fb1dea
+size 5168

--- a/Content/CR4S/_Data/Item/DT_GimmickData.uasset
+++ b/Content/CR4S/_Data/Item/DT_GimmickData.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f9300607d439c777876e41b0890f3fe9da58a7f0ce845471192426c25044f928
+size 3348

--- a/Content/CR4S/_Data/Item/DT_ItemData.uasset
+++ b/Content/CR4S/_Data/Item/DT_ItemData.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:013dacb2f52cd6c7e5bd76bb45a04d35b5b91cece9048ef6ffdbef5150732b43
-size 2827
+oid sha256:0d9b6859b20adaaa190821f167b327f077be538bcdc01bbc664aea18645030d3
+size 2749

--- a/Content/CR4S/_Data/Item/DT_ItemData.uasset
+++ b/Content/CR4S/_Data/Item/DT_ItemData.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:013dacb2f52cd6c7e5bd76bb45a04d35b5b91cece9048ef6ffdbef5150732b43
+size 2827

--- a/Source/CR4S/CR4S.Build.cs
+++ b/Source/CR4S/CR4S.Build.cs
@@ -15,16 +15,18 @@ public class CR4S : ModuleRules
 			"Engine",
 			"InputCore",
 			"EnhancedInput",
-			"UMG"
+			"UMG",
+			"Slate",
+			"SlateCore",
+			"ChaosSolverEngine",
+			"GeometryCollectionEngine"
 		});
-	
-		PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore", "EnhancedInput", "UMG", "Slate", "SlateCore",  });
 
 		PrivateDependencyModuleNames.AddRange(new string[] { "ALS", "ALSCamera" });
 
-        PublicIncludePaths.AddRange(new string[]
-        {
-            "CR4S",
+		PublicIncludePaths.AddRange(new string[]
+		{
+			"CR4S",
 		});
-    }
+	}
 }

--- a/Source/CR4S/Gimmick/Components/DestructibleComponent.h
+++ b/Source/CR4S/Gimmick/Components/DestructibleComponent.h
@@ -35,12 +35,23 @@ public:
 
 	FORCEINLINE float GetMaxHealth() const { return MaxHealth; }
 	FORCEINLINE float GetCurrentHealth() const { return CurrentHealth; }
+	FORCEINLINE bool IsDestructed() const { return CurrentHealth <= 0.0f; }
+
+	FORCEINLINE void SetMaxHealth(const float InMaxHealth)
+	{
+		MaxHealth = InMaxHealth;
+		CurrentHealth = MaxHealth;
+	}
 	
 private:
-	UPROPERTY(VisibleAnywhere, Category = "DestructibleComponent|Health")
+	
+	UPROPERTY(VisibleAnywhere, Category = "Health")
 	float MaxHealth;
-	UPROPERTY(VisibleAnywhere, Category = "DestructibleComponent|Health")
+	UPROPERTY(VisibleAnywhere, Category = "Health")
 	float CurrentHealth;
+
+	UPROPERTY(VisibleAnywhere, Category = "Health")
+	bool bCanTakeDamage;
 
 #pragma endregion
 

--- a/Source/CR4S/Gimmick/Components/InteractableComponent.cpp
+++ b/Source/CR4S/Gimmick/Components/InteractableComponent.cpp
@@ -7,7 +7,7 @@ UInteractableComponent::UInteractableComponent()
 {
 	PrimaryComponentTick.bCanEverTick = false;
 
-	InteractionText = FText::FromString("Default Interaction Text");
+	InteractionText = NSLOCTEXT("InteractableComponent", "InteractionText", "Default Interaction Text");
 
 	HighlightOpacityParamName = TEXT("HighlightOpacity");
 	HighlightColorParamName = TEXT("HighlightColor");

--- a/Source/CR4S/Gimmick/Data/BaseDataInfo.h
+++ b/Source/CR4S/Gimmick/Data/BaseDataInfo.h
@@ -4,7 +4,7 @@
 
 #include "BaseDataInfo.generated.h"
 
-USTRUCT(BlueprintType)
+USTRUCT()
 struct FBaseDataInfo : public FTableRowBase
 {
 	GENERATED_BODY()

--- a/Source/CR4S/Gimmick/GimmickObjects/BaseGimmick/DestructibleGimmick.cpp
+++ b/Source/CR4S/Gimmick/GimmickObjects/BaseGimmick/DestructibleGimmick.cpp
@@ -1,8 +1,10 @@
 ﻿#include "DestructibleGimmick.h"
 
 #include "CR4S/Gimmick/Components/DestructibleComponent.h"
+#include "Gimmick/Manager/ItemGimmickSubsystem.h"
 
 ADestructibleGimmick::ADestructibleGimmick()
+	: DestroyDelay(0.f)
 {
 	PrimaryActorTick.bCanEverTick = false;
 
@@ -17,6 +19,16 @@ void ADestructibleGimmick::BeginPlay()
 	{
 		DestructibleComponent->OnTakeDamage.BindUObject(this, &ThisClass::OnGimmickTakeDamage);
 		DestructibleComponent->OnDestroy.BindUObject(this, &ThisClass::OnGimmickDestroy);
+
+		const UItemGimmickSubsystem* GimmickSubsystem = GetGameInstance()->GetSubsystem<UItemGimmickSubsystem>();
+		if (IsValid(GimmickSubsystem))
+		{
+			const FBaseGimmickData* GimmickData = GimmickSubsystem->FindGimmickData(GetGimmickDataRowName());
+
+			check(GimmickData);
+
+			DestructibleComponent->SetMaxHealth(GimmickData->GimmickMaxHealth);
+		}
 	}
 }
 
@@ -27,6 +39,16 @@ void ADestructibleGimmick::OnGimmickTakeDamage(const float DamageAmount, const f
 }
 
 void ADestructibleGimmick::OnGimmickDestroy()
+{
+	if (DestroyDelay == 0.f)
+	{
+		DelayedDestroy();
+	}
+
+	GetWorld()->GetTimerManager().SetTimer(DestroyTimerHandle, this, &ThisClass::DelayedDestroy, DestroyDelay, false);
+}
+
+void ADestructibleGimmick::DelayedDestroy()
 {
 	UE_LOG(LogTemp, Warning, TEXT("Gimmick is destroyed"));
 

--- a/Source/CR4S/Gimmick/GimmickObjects/BaseGimmick/DestructibleGimmick.h
+++ b/Source/CR4S/Gimmick/GimmickObjects/BaseGimmick/DestructibleGimmick.h
@@ -38,4 +38,19 @@ protected:
 	TObjectPtr<UDestructibleComponent> DestructibleComponent;
 
 #pragma endregion
+
+#pragma region Destroy
+
+public:
+	FORCEINLINE void SetDestroyDelay(const float NewDelay) { DestroyDelay = NewDelay; }
+	
+private:
+	void DelayedDestroy();
+
+	FTimerHandle DestroyTimerHandle;
+	
+	UPROPERTY(EditAnywhere, Category = "Destroy", meta = (ClampMin = 0.0))
+	float DestroyDelay;
+	
+#pragma endregion
 };

--- a/Source/CR4S/Gimmick/GimmickObjects/Buildings/DoorGimmick.cpp
+++ b/Source/CR4S/Gimmick/GimmickObjects/Buildings/DoorGimmick.cpp
@@ -9,7 +9,10 @@ ADoorGimmick::ADoorGimmick()
 	  , OpenAngle(90.f)
 	  , DoorSpeed(90.f)
 	  , ClosedRotation(FRotator::ZeroRotator)
-	  , OpenRotation(FRotator::ZeroRotator), TargetRotation()
+	  , OpenRotation(FRotator::ZeroRotator)
+	  , TargetRotation()
+	  , InteractionTextOpen(NSLOCTEXT("Gimmick", "Door_Open", "Open"))
+	  , InteractionTextClose(NSLOCTEXT("Gimmick", "Door_Close", "Close"))
 {
 	PrimaryActorTick.bCanEverTick = true;
 }
@@ -74,7 +77,5 @@ void ADoorGimmick::OnGimmickInteracted()
 void ADoorGimmick::UpdateInteractionText() const
 {
 	const bool bNextWillOpen = bIsMoving ? !bNextStateIsOpen : !bIsOpen;
-	const FString InteractionString = FString::Printf(
-		TEXT("Press '2' to %s"), bNextWillOpen ? TEXT("OPEN") : TEXT("CLOSE"));
-	InteractableComponent->SetInteractionText(FText::FromString(InteractionString));
+	InteractableComponent->SetInteractionText(bNextWillOpen ? InteractionTextOpen : InteractionTextClose);
 }

--- a/Source/CR4S/Gimmick/GimmickObjects/Buildings/DoorGimmick.h
+++ b/Source/CR4S/Gimmick/GimmickObjects/Buildings/DoorGimmick.h
@@ -48,4 +48,14 @@ private:
 	FRotator TargetRotation;
 	
 #pragma endregion
+
+#pragma region Interaction
+
+private:
+	UPROPERTY(EditDefaultsOnly, Category = "Interaction")
+	FText InteractionTextOpen;
+	UPROPERTY(EditDefaultsOnly, Category = "Interaction")
+	FText InteractionTextClose;
+	
+#pragma endregion
 };

--- a/Source/CR4S/Gimmick/GimmickObjects/ResourceGimmick/ResourceGimmick.cpp
+++ b/Source/CR4S/Gimmick/GimmickObjects/ResourceGimmick/ResourceGimmick.cpp
@@ -1,0 +1,41 @@
+﻿#include "ResourceGimmick.h"
+
+#include "GeometryCollection/GeometryCollectionComponent.h"
+
+AResourceGimmick::AResourceGimmick()
+{
+	PrimaryActorTick.bCanEverTick = false;
+
+	GeometryCollectionComponent = CreateDefaultSubobject<UGeometryCollectionComponent>(TEXT("GeometryCollectionComponent"));
+	GeometryCollectionComponent->SetupAttachment(RootComponent);
+	GeometryCollectionComponent->SetVisibility(false);
+	GeometryCollectionComponent->SetCollisionEnabled(ECollisionEnabled::NoCollision);
+	GeometryCollectionComponent->SetSimulatePhysics(false);
+	GeometryCollectionComponent->DamageThreshold.Reset(2);
+}
+
+void AResourceGimmick::BeginPlay()
+{
+	Super::BeginPlay();
+
+	GeometryCollectionComponent->SetVisibility(false);
+	GeometryCollectionComponent->SetSimulatePhysics(false);
+}
+
+void AResourceGimmick::OnGimmickDestroy()
+{
+	UStaticMeshComponent* Mesh = GetStaticMeshComponent();
+	if (IsValid(Mesh))
+	{
+		Mesh->SetVisibility(false);
+		Mesh->SetCollisionEnabled(ECollisionEnabled::NoCollision);
+
+		GeometryCollectionComponent->SetVisibility(true);
+		GeometryCollectionComponent->SetCollisionEnabled(ECollisionEnabled::QueryAndPhysics);
+		GeometryCollectionComponent->SetSimulatePhysics(true);
+	}
+
+	Super::OnGimmickDestroy();
+}
+
+

--- a/Source/CR4S/Gimmick/GimmickObjects/ResourceGimmick/ResourceGimmick.h
+++ b/Source/CR4S/Gimmick/GimmickObjects/ResourceGimmick/ResourceGimmick.h
@@ -1,0 +1,28 @@
+﻿#pragma once
+
+#include "CoreMinimal.h"
+#include "Gimmick/GimmickObjects/BaseGimmick/DestructibleGimmick.h"
+#include "ResourceGimmick.generated.h"
+
+UCLASS()
+class CR4S_API AResourceGimmick : public ADestructibleGimmick
+{
+	GENERATED_BODY()
+
+#pragma region ADestructibleGimmick Override
+
+public:
+	AResourceGimmick();
+	virtual void BeginPlay() override;
+
+	virtual void OnGimmickDestroy() override;
+#pragma endregion
+
+#pragma region Components
+
+private:
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Components", meta = (AllowPrivateAccess = true))
+	TObjectPtr<UGeometryCollectionComponent> GeometryCollectionComponent;
+
+#pragma endregion
+};

--- a/Source/CR4S/Gimmick/GimmickObjects/ResourceGimmick/TreeGimmick.cpp
+++ b/Source/CR4S/Gimmick/GimmickObjects/ResourceGimmick/TreeGimmick.cpp
@@ -1,0 +1,69 @@
+﻿#include "TreeGimmick.h"
+
+ATreeGimmick::ATreeGimmick()
+	: ShakeDuration(0.5f),
+	  ShakeInterval(0.02f),
+	  ShakeIntensity(5.0f),
+	  OriginalLocation(FVector::ZeroVector),
+	  ElapsedTime(0.f)
+{
+	PrimaryActorTick.bCanEverTick = false;
+
+	StumpMeshComponent = CreateDefaultSubobject<UStaticMeshComponent>(TEXT("StumpMeshComponent"));
+	StumpMeshComponent->SetupAttachment(RootComponent);
+}
+
+void ATreeGimmick::BeginPlay()
+{
+	Super::BeginPlay();
+
+	OriginalLocation = GetActorLocation();
+}
+
+void ATreeGimmick::OnGimmickTakeDamage(const float DamageAmount, const float CurrentHealth)
+{
+	Super::OnGimmickTakeDamage(DamageAmount, CurrentHealth);
+
+	StartShake();
+}
+
+void ATreeGimmick::OnGimmickDestroy()
+{
+	Super::OnGimmickDestroy();
+}
+
+void ATreeGimmick::StartShake()
+{
+	UE_LOG(LogTemp, Warning, TEXT("==== ShakeStart ===="));
+	GetWorldTimerManager().SetTimer(
+		ShakeTimerHandle,
+		this,
+		&ThisClass::PerformShake,
+		ShakeInterval,
+		true
+	);
+}
+
+void ATreeGimmick::PerformShake()
+{
+	ElapsedTime += ShakeInterval;
+
+	if (ElapsedTime >= ShakeDuration)
+	{
+		StopShake();
+		return;
+	}
+
+	const FVector RandomOffset = FMath::VRand() * ShakeIntensity;
+
+	SetActorLocation(OriginalLocation + RandomOffset, false, nullptr, ETeleportType::TeleportPhysics);
+}
+
+void ATreeGimmick::StopShake()
+{
+	UE_LOG(LogTemp, Warning, TEXT("==== ShakeEnd ===="));
+	ElapsedTime = 0.f;
+	GetWorldTimerManager().ClearTimer(ShakeTimerHandle);
+
+	SetActorLocation(OriginalLocation, false, nullptr, ETeleportType::TeleportPhysics);
+}

--- a/Source/CR4S/Gimmick/GimmickObjects/ResourceGimmick/TreeGimmick.h
+++ b/Source/CR4S/Gimmick/GimmickObjects/ResourceGimmick/TreeGimmick.h
@@ -1,0 +1,55 @@
+﻿#pragma once
+
+#include "CoreMinimal.h"
+#include "Gimmick/GimmickObjects/BaseGimmick/DestructibleGimmick.h"
+#include "TreeGimmick.generated.h"
+
+UCLASS()
+class CR4S_API ATreeGimmick : public ADestructibleGimmick
+{
+	GENERATED_BODY()
+
+#pragma region ADestructibleGimmick Override
+
+public:
+	ATreeGimmick();
+
+	virtual void BeginPlay() override;
+	
+	virtual void OnGimmickTakeDamage(float DamageAmount, float CurrentHealth) override;
+	virtual void OnGimmickDestroy() override;
+	
+#pragma endregion
+
+#pragma region Components
+
+private:
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Components", meta = (AllowPrivateAccess = true))
+	TObjectPtr<UStaticMeshComponent> StumpMeshComponent;
+	
+#pragma endregion
+
+#pragma region Shake
+
+private:
+	void StartShake();
+	void PerformShake();
+	void StopShake();
+
+	FTimerHandle ShakeTimerHandle;
+
+	UPROPERTY(EditDefaultsOnly, Category = "Shake")
+	float ShakeDuration;
+	UPROPERTY(EditDefaultsOnly, Category = "Shake")
+	float ShakeInterval;
+	/** 떨림 강도 */
+	UPROPERTY(EditDefaultsOnly, Category = "Shake")
+	float ShakeIntensity;
+
+	UPROPERTY(VisibleAnywhere, Category = "Shake")
+	FVector OriginalLocation;
+	UPROPERTY(VisibleAnywhere, Category = "Shake")
+	float ElapsedTime;
+	
+#pragma endregion
+};

--- a/Source/CR4S/Gimmick/Manager/ItemGimmickSubsystem.cpp
+++ b/Source/CR4S/Gimmick/Manager/ItemGimmickSubsystem.cpp
@@ -6,8 +6,8 @@
 #include "Gimmick/GimmickObjects/BaseGimmick/BaseGimmick.h"
 
 UItemGimmickSubsystem::UItemGimmickSubsystem()
-	: ItemDataTable(FSoftObjectPath(TEXT("/Game/GimmickTest/Data/DT_ItemData.DT_ItemData")))
-	  , GimmickDataTable(FSoftObjectPath(TEXT("/Game/GimmickTest/Data/DT_GimmickData.DT_GimmickData")))
+	: ItemDataTable(FSoftObjectPath(TEXT("/Game/CR4S/_Data/Item/DT_ItemData.DT_ItemData")))
+	  , GimmickDataTable(FSoftObjectPath(TEXT("/Game/CR4S/_Data/Item/DT_GimmickData.DT_GimmickData")))
 	  , bIsItemDataTableLoaded(false)
 	  , bIsGimmickDataTableLoaded(false)
 {


### PR DESCRIPTION
- 아이템 기믹 서브시스템 데이터 테이블 경로 재지정
- 파괴가능 기믹이 공격 받을 수 있는 간격 추가
  - 파괴가능 컴포넌트에서 TakeDamage에 플래그로 현재 피해를 받을 수 있는지 체크 후 로직 진행
- 파괴가능 기믹이 파괴 될때 엑터가 사라질 때까지 걸리는 시간 조절 가능하도록 수정
- UGeometryCollectionComponent를 활용하여 파괴되는 효과 추가
- 나무 기믹 및 자원 기믹(바위, 광석) 추가
- 상호작용 UI 테스트 폴더에서 프로젝트 폴더로 이동