### PR TITLE
[Update] CombatComponent & Related things

### DIFF
--- a/CR4S.sln.DotSettings.user
+++ b/CR4S.sln.DotSettings.user
@@ -1,0 +1,5 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeInspection/PencilsConfiguration/ActualSeverity/@EntryValue">INFO</s:String>
+	<s:String x:Key="/Default/CodeInspection/PencilsConfiguration/FiltersState/=CodeStyle/@EntryIndexedValue">On</s:String>
+	<s:String x:Key="/Default/CodeInspection/PencilsConfiguration/FiltersState/=NamingFilter/@EntryIndexedValue">On</s:String>
+	<s:String x:Key="/Default/CodeInspection/PencilsConfiguration/FiltersState/=SpellingFilter/@EntryIndexedValue">On</s:String></wpf:ResourceDictionary>

--- a/Content/CR4S/Animation/Retarget/ABP_MechanicGirl.uasset
+++ b/Content/CR4S/Animation/Retarget/ABP_MechanicGirl.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:652cc5c1098d0aefc188311068f7ede0fe13cd7d50271c4e939751a856b99052
+size 226895

--- a/Content/CR4S/Animation/Retarget/IK_Als.uasset
+++ b/Content/CR4S/Animation/Retarget/IK_Als.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b15c55c91e788bc8e8bae8d8a2dcaa98ae4bc68cf220ea495e73eee898d3657e
+size 79454

--- a/Content/CR4S/Animation/Retarget/IK_MechanicGirl.uasset
+++ b/Content/CR4S/Animation/Retarget/IK_MechanicGirl.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f4916ddf7ced4e53b45db9506926fb7028bba0ede3422e4c816af78318c3dc64
+size 92862

--- a/Content/CR4S/Animation/Retarget/RTG_MechanicGirl.uasset
+++ b/Content/CR4S/Animation/Retarget/RTG_MechanicGirl.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fbb4972b47f5083936f689ef2f1aef109e387149c58aa92189eb6c5454a3e86f
+size 16502

--- a/Content/CR4S/Inputs/Character/IA_Attack.uasset
+++ b/Content/CR4S/Inputs/Character/IA_Attack.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:34fc7f0f1ae674e182938653ceb3cf9085f794220a968324a411b35f10caa0c3
+size 1394

--- a/Content/CR4S/Inputs/Character/IMC_PlayerCharacter.uasset
+++ b/Content/CR4S/Inputs/Character/IMC_PlayerCharacter.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e03826c4f95878994bd974a2053263798bb5ee5e6e7e190c8c36a430f5157329
+size 23176

--- a/Content/CR4S/Inputs/IA_Jump.uasset
+++ b/Content/CR4S/Inputs/IA_Jump.uasset
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:22c5b9c7f86524692023a2bb61a28430516ceb1b639b35dee2ed42860e101e45
-size 1364

--- a/Content/CR4S/Inputs/IA_Look.uasset
+++ b/Content/CR4S/Inputs/IA_Look.uasset
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dfb78eaa939cca85f5f5b594abceba66afc0b56c1fc385670cc4fcfdae38b71d
-size 1560

--- a/Content/CR4S/Inputs/IA_Move.uasset
+++ b/Content/CR4S/Inputs/IA_Move.uasset
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bc18c1c8557cc4997791de2ebaba8a4fcdd30e76ada22de208d323958c23463c
-size 1560

--- a/Content/CR4S/Inputs/IA_Sprint.uasset
+++ b/Content/CR4S/Inputs/IA_Sprint.uasset
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:200aa79dd6d6d1137a3e146a30ed8911a05779c5f1391ec66c529b332332b961
-size 1374

--- a/Content/CR4S/Inputs/IMC_Default.uasset
+++ b/Content/CR4S/Inputs/IMC_Default.uasset
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e274fa17fdbf2b00e6acef734b601eca0cb3864918787335ef3ea38eed6ea79f
-size 8168

--- a/Content/CR4S/Inputs/Robot/IA_Jump.uasset
+++ b/Content/CR4S/Inputs/Robot/IA_Jump.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bbe6afd5c20b03e9d50f68bb8461ef7cc5275739be84b1199f34913f5dd5460b
+size 1376

--- a/Content/CR4S/Inputs/Robot/IA_Look.uasset
+++ b/Content/CR4S/Inputs/Robot/IA_Look.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:16d36d77a527cb14949a2d6fd8bda0dd927b720437ed7bac5e8b25e7fcc975c0
+size 1572

--- a/Content/CR4S/Inputs/Robot/IA_Move.uasset
+++ b/Content/CR4S/Inputs/Robot/IA_Move.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8f04889b04ea70b00c501fa4780afda488a077ad0aa90bfdaf9ce12e5cf4e353
+size 1572

--- a/Content/CR4S/Inputs/Robot/IA_Sprint.uasset
+++ b/Content/CR4S/Inputs/Robot/IA_Sprint.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68a7bdaaa8c80dc9b16b0ef8b232cfd1212670cf78f27c6d095db4ea57dcc2fd
+size 1386

--- a/Content/CR4S/Inputs/Robot/IMC_Default.uasset
+++ b/Content/CR4S/Inputs/Robot/IMC_Default.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d48f7c9328840e2cc3b71e4faa027d2c1da2e9d962293c87a79c3b09b0b2e244
+size 8222

--- a/Content/CR4S/_Blueprint/Character/BP_Player.uasset
+++ b/Content/CR4S/_Blueprint/Character/BP_Player.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c58ec7b782db06ce6efcd60a27466830942e8b68cc93bd41350a1fb5f4dad37f
-size 257505
+oid sha256:eedb38c239d0a2869fbecf5cb071adc2a20c2637e98df73cfd0104a64f96d608
+size 258495

--- a/Content/CR4S/_Blueprint/Character/BP_Player.uasset
+++ b/Content/CR4S/_Blueprint/Character/BP_Player.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:86ce68515cb3695bada1fd0c87fd9e2d372c49030af5d6d3515e0b4ed0f85b19
-size 258809
+oid sha256:c58ec7b782db06ce6efcd60a27466830942e8b68cc93bd41350a1fb5f4dad37f
+size 257505

--- a/Content/CR4S/_Blueprint/FrameWork/Controller/BP_CharacterController.uasset
+++ b/Content/CR4S/_Blueprint/FrameWork/Controller/BP_CharacterController.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2be186ff1d4e6409e504d5e04431bd9804b0c6aece6a5aa79776858b6e90c9da
-size 21322
+oid sha256:5ccc6ba4a6c16f74c52feaf42a735a9bcafa9540bead64a373531218b201282e
+size 21404

--- a/Content/MechanicGirl/Mesh/SK_MechanicGirl_05.uasset
+++ b/Content/MechanicGirl/Mesh/SK_MechanicGirl_05.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1f9f633106f346dc764f76388f1da44297b65beb0a4c402877364af1f0dffad7
+size 10966551

--- a/Content/MechanicGirl/Mesh/UE4_Mannequin_Skeleton.uasset
+++ b/Content/MechanicGirl/Mesh/UE4_Mannequin_Skeleton.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cbd1f0ceeebb89ae1d8fcfc6e9c4cb0165f74821e6e34b325bcfcdba74d25a4b
-size 20832
+oid sha256:1a894d98fac84262d8e2279357d1879a007a9af2e9f12a3d72d8b64690fdf42c
+size 66985

--- a/Plugins/ALS-Refactored-4.15/Content/ALS/Animations/Actions/Roll/AM_Attack.uasset
+++ b/Plugins/ALS-Refactored-4.15/Content/ALS/Animations/Actions/Roll/AM_Attack.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2763a3e4f135b0d7ba361b397431eb6de18ebb705d0b52207a70d3236d7538cb
+size 24861

--- a/Plugins/ALS-Refactored-4.15/Content/ALS/Character/SKM_Als.uasset
+++ b/Plugins/ALS-Refactored-4.15/Content/ALS/Character/SKM_Als.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dc5a3fde1b293fc2bcab6751e4f43d843923b649263e702fe82f0ef7064273c8
-size 2606592
+oid sha256:4a512ed8890404fbe80e65081b788bd9a5baf5a8e6a82ad608b4cc2518588259
+size 2299695

--- a/Plugins/ALS-Refactored-4.15/Content/ALS/Character/SK_Als.uasset
+++ b/Plugins/ALS-Refactored-4.15/Content/ALS/Character/SK_Als.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0e9e2ef8429af6a0b32856e5f98386d06a237cf3001006bca50a21275c10a4dd
-size 46437
+oid sha256:450688c9475e6b50b64830debb6d81904163ad803edf109071a7dbac72f63912
+size 52294

--- a/Source/CR4S/Character/AnimNotify/InputDisabled.cpp
+++ b/Source/CR4S/Character/AnimNotify/InputDisabled.cpp
@@ -1,0 +1,34 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "InputDisabled.h"
+#include "Character/Components/CombatComponent.h"
+#include "GameFramework/Character.h"
+
+void UInputDisabled::NotifyBegin(USkeletalMeshComponent* MeshComp, UAnimSequenceBase* Animation, float TotalDuration,
+                                 const FAnimNotifyEventReference& EventReference)
+{
+	ACharacter* OwningCharacter=Cast<ACharacter>(MeshComp->GetOwner());
+	if (!OwningCharacter) return;
+
+	UCombatComponent* Combat=OwningCharacter->FindComponentByClass<UCombatComponent>();
+	if (!Combat) return;
+
+	Combat->SetInputEnable(false);
+	
+	//Super::NotifyBegin(MeshComp, Animation, TotalDuration, EventReference);
+}
+
+void UInputDisabled::NotifyEnd(USkeletalMeshComponent* MeshComp, UAnimSequenceBase* Animation,
+	const FAnimNotifyEventReference& EventReference)
+{
+	ACharacter* OwningCharacter=Cast<ACharacter>(MeshComp->GetOwner());
+	if (!OwningCharacter) return;
+
+	UCombatComponent* Combat=OwningCharacter->FindComponentByClass<UCombatComponent>();
+	if (!Combat) return;
+
+	Combat->SetInputEnable(true);
+	
+	//Super::NotifyEnd(MeshComp, Animation, EventReference);
+}

--- a/Source/CR4S/Character/AnimNotify/InputDisabled.h
+++ b/Source/CR4S/Character/AnimNotify/InputDisabled.h
@@ -1,0 +1,20 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Animation/AnimNotifies/AnimNotifyState.h"
+#include "InputDisabled.generated.h"
+
+/**
+ * 
+ */
+UCLASS()
+class CR4S_API UInputDisabled : public UAnimNotifyState
+{
+	GENERATED_BODY()
+#pragma region OverrideFunctions
+	virtual void NotifyBegin(USkeletalMeshComponent* MeshComp, UAnimSequenceBase* Animation, float TotalDuration, const FAnimNotifyEventReference& EventReference) override;
+	virtual void NotifyEnd(USkeletalMeshComponent* MeshComp, UAnimSequenceBase* Animation, const FAnimNotifyEventReference& EventReference) override;
+#pragma endregion
+};

--- a/Source/CR4S/Character/Characters/PlayerCharacter.cpp
+++ b/Source/CR4S/Character/Characters/PlayerCharacter.cpp
@@ -2,6 +2,8 @@
 #include "AlsCameraComponent.h"
 #include "EnhancedInputComponent.h"
 #include "EnhancedInputSubsystems.h"
+#include "Character/Components/CombatComponent.h"
+#include "Character/Components/PlayerCharacterStatusComponent.h"
 #include "Engine/LocalPlayer.h"
 #include "GameFramework/PlayerController.h"
 #include "Utility/AlsVector.h"
@@ -13,6 +15,10 @@ APlayerCharacter::APlayerCharacter()
 	Camera = CreateDefaultSubobject<UAlsCameraComponent>(FName{TEXTVIEW("Camera")});
 	Camera->SetupAttachment(GetMesh());
 	Camera->SetRelativeRotation_Direct({0.0f, 90.0f, 0.0f});
+
+	Combat=CreateDefaultSubobject<UCombatComponent>(FName{TEXTVIEW("Combat")});
+
+	Status=CreateDefaultSubobject<UPlayerCharacterStatusComponent>(FName{TEXTVIEW("Status")});
 }
 
 void APlayerCharacter::NotifyControllerChanged()
@@ -84,6 +90,7 @@ void APlayerCharacter::SetupPlayerInputComponent(UInputComponent* Input)
 		EnhancedInput->BindAction(RotationModeAction, ETriggerEvent::Triggered, this, &ThisClass::Input_OnRotationMode);
 		EnhancedInput->BindAction(ViewModeAction, ETriggerEvent::Triggered, this, &ThisClass::Input_OnViewMode);
 		EnhancedInput->BindAction(SwitchShoulderAction, ETriggerEvent::Triggered, this, &ThisClass::Input_OnSwitchShoulder);
+		EnhancedInput->BindAction(AttackAction,ETriggerEvent::Triggered,Combat.Get(),&UCombatComponent::Input_OnAttack);
 	}
 }
 

--- a/Source/CR4S/Character/Characters/PlayerCharacter.h
+++ b/Source/CR4S/Character/Characters/PlayerCharacter.h
@@ -6,6 +6,8 @@
 #include "AlsCharacter.h"
 #include "PlayerCharacter.generated.h"
 
+class UPlayerCharacterStatusComponent;
+class UCombatComponent;
 struct FInputActionValue;
 class UAlsCameraComponent;
 class UInputMappingContext;
@@ -61,6 +63,10 @@ private:
 protected:
 	UPROPERTY(VisibleDefaultsOnly, BlueprintReadOnly, Category = "Player Character")
 	TObjectPtr<UAlsCameraComponent> Camera;
+	UPROPERTY(VisibleDefaultsOnly, BlueprintReadOnly, Category = "Player Character")
+	TObjectPtr<UCombatComponent> Combat;
+	UPROPERTY(VisibleDefaultsOnly, BlueprintReadOnly, Category = "Player Character")
+	TObjectPtr<UPlayerCharacterStatusComponent> Status;
 #pragma endregion
 
 #pragma region InputActions
@@ -106,6 +112,9 @@ protected:
 
 	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Settings|Player Character", Meta = (DisplayThumbnail = false))
 	TObjectPtr<UInputAction> SwitchShoulderAction;
+
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Settings|Player Character", Meta = (DisplayThumbnail = false))
+	TObjectPtr<UInputAction> AttackAction;
 #pragma endregion
 	
 #pragma region LookSettings

--- a/Source/CR4S/Character/Components/CombatComponent.cpp
+++ b/Source/CR4S/Character/Components/CombatComponent.cpp
@@ -1,0 +1,49 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "CombatComponent.h"
+#include "Character/Characters/PlayerCharacter.h"
+
+
+// Sets default values for this component's properties
+UCombatComponent::UCombatComponent():
+	bInputEnable(true)
+{
+	// Set this component to be initialized when the game starts, and to be ticked every frame.  You can turn these features
+	// off to improve performance if you don't need them.
+	PrimaryComponentTick.bCanEverTick = true;
+	
+	// ...
+}
+
+void UCombatComponent::Input_OnAttack()
+{
+	if (!bInputEnable) return;
+	OwningCharacter->PlayAnimMontage(AttackMontage);
+}
+
+void UCombatComponent::SetInputEnable(bool Enable)
+{
+	bInputEnable=Enable;
+}
+
+
+// Called when the game starts
+void UCombatComponent::BeginPlay()
+{
+	Super::BeginPlay();
+	
+	OwningCharacter=Cast<APlayerCharacter>(GetOwner());
+	
+}
+
+
+// Called every frame
+void UCombatComponent::TickComponent(float DeltaTime, ELevelTick TickType,
+                                     FActorComponentTickFunction* ThisTickFunction)
+{
+	Super::TickComponent(DeltaTime, TickType, ThisTickFunction);
+
+	// ...
+}
+

--- a/Source/CR4S/Character/Components/CombatComponent.h
+++ b/Source/CR4S/Character/Components/CombatComponent.h
@@ -1,0 +1,54 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Components/ActorComponent.h"
+#include "CombatComponent.generated.h"
+
+
+class APlayerCharacter;
+
+UCLASS(ClassGroup=(Custom), meta=(BlueprintSpawnableComponent))
+class CR4S_API UCombatComponent : public UActorComponent
+{
+	GENERATED_BODY()
+
+public:
+	// Sets default values for this component's properties
+	UCombatComponent();
+	
+#pragma region Attack
+public:
+	void Input_OnAttack();
+#pragma endregion
+
+#pragma region InputState
+	void SetInputEnable(bool Enable);
+#pragma endregion
+	
+#pragma region OverrideFunctions
+public:
+	// Called every frame
+	virtual void TickComponent(float DeltaTime, ELevelTick TickType,FActorComponentTickFunction* ThisTickFunction) override;
+protected:
+	// Called when the game starts
+	virtual void BeginPlay() override;
+#pragma endregion
+
+#pragma region AnimationMontage
+	UPROPERTY(EditAnywhere,BlueprintReadWrite,Category="Animations")
+	TObjectPtr<UAnimMontage> AttackMontage;
+#pragma endregion
+	
+	
+#pragma region Owner
+protected:
+	UPROPERTY(VisibleAnywhere,BlueprintReadOnly,Category="Owner")
+	TObjectPtr<APlayerCharacter> OwningCharacter;
+#pragma endregion
+
+#pragma region Cached
+	uint8 bInputEnable:1;
+#pragma endregion
+};


### PR DESCRIPTION
### CombatComponent 업데이트
- AnimNotifyState를 활용한 입력 차단
- 공격용 함수 추가 (Input_OnAttack) 및 플레이어 캐릭터에서 바인딩
### AnimNotifyState
- 몽타주에서 입력 차단 구간 설정을 위해 사용
- 시작 및 종료 지점에서 호출되는 함수 오버라이드
- Component 캐스팅 과정에서 FindComponentByClass 사용 -> Robot, Player 모두 해당 AnimNotifyState 사용 가능 (공통 조상 Character만 캐스팅하여 컴포넌트를 찾을 수 있음)