### PR TITLE
[HotFix] Destructible Gimmick TakeDamage Logic

### DIFF
--- a/Source/CR4S/Gimmick/Components/DestructibleComponent.cpp
+++ b/Source/CR4S/Gimmick/Components/DestructibleComponent.cpp
@@ -15,7 +15,7 @@ void UDestructibleComponent::InitComponent(const float InMaxHealth)
 	CurrentHealth = InMaxHealth;
 }
 
-void UDestructibleComponent::TakeDamage(AController* DamageCauserController, const float DamageAmount)
+void UDestructibleComponent::TakeDamage(AActor* DamageCauser, const float DamageAmount)
 {
 	if (!bCanTakeDamage || IsDestructed())
 	{
@@ -24,7 +24,7 @@ void UDestructibleComponent::TakeDamage(AController* DamageCauserController, con
 
 	bCanTakeDamage = false;
 
-	LastDamageCauserController = DamageCauserController;
+	LastDamageCauser = DamageCauser;
 
 	CurrentHealth = FMath::Max(CurrentHealth - DamageAmount, 0.f);
 

--- a/Source/CR4S/Gimmick/Components/DestructibleComponent.h
+++ b/Source/CR4S/Gimmick/Components/DestructibleComponent.h
@@ -49,9 +49,9 @@ private:
 
 public:
 	UFUNCTION(BlueprintCallable, Category = "DestructibleComponent|Hit")
-	void TakeDamage(AController* DamageCauserController, float DamageAmount);
+	void TakeDamage(AActor* DamageCauser, float DamageAmount);
 
-	FORCEINLINE AController* GetLastDamageCauserController() const { return LastDamageCauserController; }
+	FORCEINLINE AActor* GetLastDamageCauser() const { return LastDamageCauser; }
 
 private:
 	UPROPERTY(EditDefaultsOnly, Category = "Hit", meta = (ClampMin = "0.0"))
@@ -61,7 +61,7 @@ private:
 	bool bCanTakeDamage;
 
 	UPROPERTY(VisibleAnywhere, Category = "Hit")
-	TObjectPtr<AController> LastDamageCauserController;
+	TObjectPtr<AActor> LastDamageCauser;
 
 #pragma endregion
 

--- a/Source/CR4S/Gimmick/GimmickObjects/DestructibleResourceGimmick.cpp
+++ b/Source/CR4S/Gimmick/GimmickObjects/DestructibleResourceGimmick.cpp
@@ -55,6 +55,22 @@ void ADestructibleResourceGimmick::BeginPlay()
 	}
 }
 
+float ADestructibleResourceGimmick::TakeDamage(float DamageAmount, struct FDamageEvent const& DamageEvent,
+	AController* EventInstigator, AActor* DamageCauser)
+{
+	const float Damage =Super::TakeDamage(DamageAmount, DamageEvent, EventInstigator, DamageCauser);
+
+	if (!IsValid(DestructibleComponent))
+	{
+		UE_LOG(LogTemp, Warning, TEXT("DestructibleComponent is not valid"));
+		return 0.f;
+	}
+	
+	DestructibleComponent->TakeDamage(DamageCauser, Damage);
+	
+	return Damage;
+}
+
 void ADestructibleResourceGimmick::OnGimmickTakeDamage(const float DamageAmount, const float CurrentHealth)
 {
 	UE_LOG(LogTemp, Warning, TEXT("Gimmick is damaged / DamageAmount: %.1f / CurrentHealth: %.1f"), DamageAmount,
@@ -105,30 +121,22 @@ void ADestructibleResourceGimmick::GetResourceItem() const
 		return;
 	}
 
-	ACharacterController* CharacterController
-		= Cast<ACharacterController>(DestructibleComponent->GetLastDamageCauserController());
-	if (!IsValid(CharacterController))
+	const AActor* DamageCauser = Cast<AActor>(DestructibleComponent->GetLastDamageCauser());
+	if (!IsValid(DamageCauser))
 	{
-		UE_LOG(LogTemp, Warning, TEXT("CharacterController is not valid"));
-		return;
-	}
-
-	APlayerCharacter* PlayerCharacter = Cast<APlayerCharacter>(CharacterController->GetPawn());
-	if (!IsValid(PlayerCharacter))
-	{
-		UE_LOG(LogTemp, Warning, TEXT("PlayerCharacter is not valid"));
+		UE_LOG(LogTemp, Warning, TEXT("DamageCauser is not valid"));
 		return;
 	}
 
 	UInventorySystemComponent* InventorySystem
-		= PlayerCharacter->FindComponentByClass<UInventorySystemComponent>();
+		= DamageCauser->FindComponentByClass<UInventorySystemComponent>();
 	if (!IsValid(InventorySystem))
 	{
 		UE_LOG(LogTemp, Warning, TEXT("InventorySystem is not valid"));
 		return;
 	}
 
-	UItemGimmickSubsystem* ItemGimmickSubsystem = GetGameInstance()->GetSubsystem<UItemGimmickSubsystem>();
+	const UItemGimmickSubsystem* ItemGimmickSubsystem = GetGameInstance()->GetSubsystem<UItemGimmickSubsystem>();
 	if (!IsValid(ItemGimmickSubsystem))
 	{
 		UE_LOG(LogTemp, Warning, TEXT("ItemGimmickSubsystem is not valid"));

--- a/Source/CR4S/Gimmick/GimmickObjects/DestructibleResourceGimmick.h
+++ b/Source/CR4S/Gimmick/GimmickObjects/DestructibleResourceGimmick.h
@@ -19,6 +19,8 @@ public:
 
 	virtual void BeginPlay() override;
 
+	virtual float TakeDamage(float DamageAmount, struct FDamageEvent const& DamageEvent, AController* EventInstigator, AActor* DamageCauser) override;
+	
 #pragma endregion
 	
 #pragma region UDestructibleComponent


### PR DESCRIPTION
- 파괴 가능 기믹의 피격 판정 로직 수정

- 기존: 공격 주체에서 공격할 대상이 파괴 가능 컴포넌트를 가지고 있는지 확인 후 공격
- 수정: 기믹에게 공격하면 알아서 컴포넌트 함수 호출하여 피해 입음

- 공격 주체를 컨트롤러로 제한 했었는데 엑터로 확장
- 파괴 후 재료 획득 로직에서도 해당 엑터가 인벤토리를 가지고 있는지 확인 후 있다면 아이템 획득 하도록 수정