### PR TITLE
[Ref] Refectoring Find Nearest House Actor

### DIFF
--- a/Content/CR4S/_Blueprint/MonsterAI/BehaviorTree/BT_HiemsFrostBoss.uasset
+++ b/Content/CR4S/_Blueprint/MonsterAI/BehaviorTree/BT_HiemsFrostBoss.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:138d760c3968bdf5b1e724156b45f340b07d2ac890f175b3073419fa9dd1abda
-size 31573
+oid sha256:6080ed55fb06876735616e9ad1b29428ca42cc6e5a27b22446d2bd249b152f20
+size 33383

--- a/Content/CR4S/_Blueprint/MonsterAI/BossMonster/Season/BP_CeresRainyBossMonster.uasset
+++ b/Content/CR4S/_Blueprint/MonsterAI/BossMonster/Season/BP_CeresRainyBossMonster.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5fdd233a5ece7802d9b5edcdf213f073ac9685dbb3dc066d3d43d42adefc9af6
-size 34544
+oid sha256:bcc5dd4d6f75b7a966f84101d8f961733a1816acd5af685adcdcefe741798870
+size 34758

--- a/Content/CR4S/_Blueprint/MonsterAI/BossMonster/Season/BP_HiemsFrostBossMonster.uasset
+++ b/Content/CR4S/_Blueprint/MonsterAI/BossMonster/Season/BP_HiemsFrostBossMonster.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4259bb40cd0045fa8d72d2fda1c7345e60d64d86c005202765f98776c813be54
-size 36225
+oid sha256:24899f20d48770bbb07231f4d4f581d3deae2da43e7a3fdd572b2b05efd51725
+size 36440

--- a/Content/CR4S/_Level/TestSeasonBoss.umap
+++ b/Content/CR4S/_Level/TestSeasonBoss.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:45dfe4a4c4bb74a860adbe8b12bf98f9b0de1d70ceab0a549bf7865401331180
-size 847318
+oid sha256:9fdc66dd241aa6bcf8d3d3536c24a69b24a3f014fb92dead9e81806283a2283d
+size 844879

--- a/Source/CR4S/MonsterAI/BossMonster/Season/SeasonBossMonster.cpp
+++ b/Source/CR4S/MonsterAI/BossMonster/Season/SeasonBossMonster.cpp
@@ -1,7 +1,14 @@
 #include "MonsterAI/BossMonster/Season/SeasonBossMonster.h"
+#include "CR4S.h"
+#include "NavigationInvokerComponent.h"
+
+ASeasonBossMonster::ASeasonBossMonster()
+{
+   NavInvoker = CreateDefaultSubobject<UNavigationInvokerComponent>(TEXT("NavInvoker"));
+   NavInvoker->SetGenerationRadii(NavInvokerRadius, NavInvokerRemovalRadius);
+}
 
 void ASeasonBossMonster::BeginPlay()
 {
    Super::BeginPlay();
 }
-

--- a/Source/CR4S/MonsterAI/BossMonster/Season/SeasonBossMonster.h
+++ b/Source/CR4S/MonsterAI/BossMonster/Season/SeasonBossMonster.h
@@ -5,11 +5,25 @@
 #include "SeasonBossMonster.generated.h"
 
 
+class UNavigationInvokerComponent;
+
 UCLASS()
 class CR4S_API ASeasonBossMonster : public ABaseMonster
 {
 	GENERATED_BODY()
 
 public:
+	ASeasonBossMonster();
+
+protected:
 	virtual void BeginPlay() override;
+
+	UPROPERTY(EditAnywhere, Category = "MonsterAI")
+	UNavigationInvokerComponent* NavInvoker;
+
+private:
+	float NavInvokerRadius = 2000.0f;
+	float NavInvokerRemovalRadius = 2500.f;
+
+	FString MyHeader = TEXT("SeasonMonster");
 };

--- a/Source/CR4S/MonsterAI/Controller/SeasonBossMonsterAIController.cpp
+++ b/Source/CR4S/MonsterAI/Controller/SeasonBossMonsterAIController.cpp
@@ -21,9 +21,6 @@ void ASeasonBossMonsterAIController::OnPossess(APawn* InPawn)
 void ASeasonBossMonsterAIController::BeginPlay()
 {
 	Super::BeginPlay();
-
-	BlackboardComp->SetValueAsVector(FSeasonBossAIKeys::InitializeTargetLocation, GetPlayerInitialLocation());
-	BlackboardComp->SetValueAsObject(FSeasonBossAIKeys::NearestHouseActor, GetNearestHouseActor(GetPlayerInitialLocation()));
 }
 
 void ASeasonBossMonsterAIController::Tick(float DeltaSeconds)
@@ -31,53 +28,11 @@ void ASeasonBossMonsterAIController::Tick(float DeltaSeconds)
 	Super::Tick(DeltaSeconds);
 
 	AActor* Target = Cast<AActor>(BlackboardComp->GetValueAsObject(FAIKeys::TargetActor));
-	AActor* NearestHouse = nullptr;
 	if (!Target)
-		NearestHouse = Cast<AActor>(BlackboardComp->GetValueAsObject(FSeasonBossAIKeys::NearestHouseActor));
-	
+		Target = Cast<AActor>(BlackboardComp->GetValueAsObject(FSeasonBossAIKeys::NearestHouseActor));
+
 	if (Target)
 		SetFocus(Target, EAIFocusPriority::Gameplay);
-	else if (NearestHouse)
-		SetFocus(NearestHouse, EAIFocusPriority::Gameplay);
 	else
 		ClearFocus(EAIFocusPriority::Gameplay);
-}
-
-FVector ASeasonBossMonsterAIController::GetPlayerInitialLocation() const
-{
-	ACharacter* TargetPlayer = UGameplayStatics::GetPlayerCharacter(GetWorld(), 0);
-
-	if (!TargetPlayer)
-	{
-		return FVector::ZeroVector;
-	}
-
-	return TargetPlayer->GetActorLocation();
-}
-
-AActor* ASeasonBossMonsterAIController::GetNearestHouseActor(const FVector& PlayerLocation) const
-{
-	TArray<AActor*> Houses;
-	UGameplayStatics::GetAllActorsWithTag(GetWorld(), TEXT("House"), Houses);
-
-	if (Houses.Num() <= 0)
-	{
-		return nullptr;
-	}
-
-	float NearestDistance = FLT_MAX;
-	AActor* NearestActor = nullptr;
-
-	for (AActor* FindActor : Houses)
-	{
-		float Distance = FVector::DistSquared(FindActor->GetActorLocation(), PlayerLocation);
-
-		if (Distance < NearestDistance)
-		{
-			NearestDistance = Distance;
-			NearestActor = FindActor;
-		}
-	}
-
-	return NearestActor;
 }

--- a/Source/CR4S/MonsterAI/Controller/SeasonBossMonsterAIController.h
+++ b/Source/CR4S/MonsterAI/Controller/SeasonBossMonsterAIController.h
@@ -16,12 +16,6 @@ public:
 	virtual void BeginPlay() override;
 	virtual void Tick(float DeltaSeconds) override;
 
-	UFUNCTION(BlueprintCallable, Category = "BossAI")
-	FVector GetPlayerInitialLocation() const;
-
-	UFUNCTION(BlueprintCallable, Category = "BossAI")
-	AActor* GetNearestHouseActor(const FVector& PlayerLocation) const;
-
 private:
 	FString MyHeader;
 };

--- a/Source/CR4S/MonsterAI/Task/BTTask_PlayAttackMontage.h
+++ b/Source/CR4S/MonsterAI/Task/BTTask_PlayAttackMontage.h
@@ -21,6 +21,8 @@ protected:
 
 	UPROPERTY(EditAnywhere, Category = "Blackboard")
 	FBlackboardKeySelector SkillIndexKey;
+	
+	UPROPERTY(EditAnywhere, Category = "Blackboard")
 	FBlackboardKeySelector bIsPlayingAttackMontage;
 
 private:

--- a/Source/CR4S/MonsterAI/Task/Season/BTService_CheckNearestHouse.cpp
+++ b/Source/CR4S/MonsterAI/Task/Season/BTService_CheckNearestHouse.cpp
@@ -1,0 +1,80 @@
+#include "MonsterAI/Task/Season/BTService_CheckNearestHouse.h"
+#include "CR4S.h"
+#include "BehaviorTree/BlackboardComponent.h"
+#include "GameFramework/Character.h"
+#include "Kismet/GameplayStatics.h"
+
+UBTService_CheckNearestHouse::UBTService_CheckNearestHouse()
+{
+	NodeName = TEXT("CheckNearestHouse");
+	Interval = 1.5f;
+	bCreateNodeInstance = true;
+}
+
+void UBTService_CheckNearestHouse::TickNode(UBehaviorTreeComponent& OwnerComp, uint8* NodeMemory, float DeltaSeconds)
+{
+	Super::TickNode(OwnerComp, NodeMemory, DeltaSeconds);
+
+	UBlackboardComponent* BlackboardComp = OwnerComp.GetBlackboardComponent();
+	if (!IsValid(BlackboardComp)) return;
+	
+	AActor* NearestHouse = Cast<AActor>(BlackboardComp->GetValueAsObject(NearestHouseActor.SelectedKeyName));
+	
+	if (!IsValid(NearestHouse))
+	{
+		const FVector PlayerLoc = UGameplayStatics::GetPlayerCharacter(GetWorld(), 0)->GetActorLocation();
+		
+		AActor* NewNearestHouse = FindNearestHouse(PlayerLoc);
+		
+		BlackboardComp->SetValueAsObject(NearestHouseActor.SelectedKeyName, NewNearestHouse);
+	}
+}
+
+void UBTService_CheckNearestHouse::OnBecomeRelevant(UBehaviorTreeComponent& OwnerComp, uint8* NodeMemory)
+{
+	Super::OnBecomeRelevant(OwnerComp, NodeMemory);
+
+	if (!NearestHouseActor.SelectedKeyName.IsValid())
+	{
+		CR4S_Log(LogDa, Warning, TEXT("[BTService_CheckNearestHouse] InValid NearestHouse"));
+		return;
+	}
+	
+	UBlackboardComponent* BlackboardComp = OwnerComp.GetBlackboardComponent();
+	if (BlackboardComp)
+	{
+		FVector PlayerLoc = UGameplayStatics::GetPlayerCharacter(GetWorld(), 0)->GetActorLocation();
+		AActor* Nearest = FindNearestHouse(PlayerLoc);
+		BlackboardComp->SetValueAsObject(NearestHouseActor.SelectedKeyName, Nearest);
+	}
+	
+}
+
+AActor* UBTService_CheckNearestHouse::FindNearestHouse(const FVector& PlayerLocation) const
+{
+	TArray<AActor*> Houses;
+	UGameplayStatics::GetAllActorsWithTag(GetWorld(), HouseTag, Houses);
+
+	if (Houses.Num() <= 0)
+	{
+		return nullptr;
+	}
+
+	float NearestDistance = FLT_MAX;
+	AActor* NearestActor = nullptr;
+
+	for (AActor* FindActor : Houses)
+	{
+		if (!IsValid(FindActor)) continue;
+		
+		float Distance = FVector::DistSquared(FindActor->GetActorLocation(), PlayerLocation);
+
+		if (Distance < NearestDistance)
+		{
+			NearestDistance = Distance;
+			NearestActor = FindActor;
+		}
+	}
+
+	return NearestActor;
+}

--- a/Source/CR4S/MonsterAI/Task/Season/BTService_CheckNearestHouse.h
+++ b/Source/CR4S/MonsterAI/Task/Season/BTService_CheckNearestHouse.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "BehaviorTree/BTService.h"
+#include "BTService_CheckNearestHouse.generated.h"
+
+UCLASS()
+class CR4S_API UBTService_CheckNearestHouse : public UBTService
+{
+	GENERATED_BODY()
+	
+public:
+	UBTService_CheckNearestHouse();
+
+protected:
+	virtual void TickNode(
+		UBehaviorTreeComponent& OwnerComp,
+		uint8* NodeMemory,
+		float DeltaSeconds
+	) override;
+	
+	virtual void OnBecomeRelevant(
+		UBehaviorTreeComponent& OwnerComp,
+		uint8* NodeMemory
+	) override;
+
+private:
+	UPROPERTY(EditAnywhere, Category = "Blackboard")
+	FBlackboardKeySelector NearestHouseActor;
+
+	UPROPERTY(EditAnywhere, Category = "Service")
+	FName HouseTag = TEXT("House");
+
+	AActor* FindNearestHouse(const FVector& PlayerLocation) const;
+};


### PR DESCRIPTION
[수정 내용]
1. AIController에서 하던 집 찾기 로직 BT Service로 이동
2. 집 처음 1번만 찾는거 InValid 할 때마다 찾아오는걸로 로직 수정
3. 계절보스 공통 Nav Invoker 추가
4. 계절보스 BehaviorTree 노드 수정
5. 산성파도 회전 로직 수정(Mesh Pivot Bottom 적용)
6. 산성파도 위치 오프셋 수정(기존 AcidWaveActor -> 수정 후 SpawnActor Notify)