### PR TITLE
[Add] Advance TimeOfDay Func

### DIFF
--- a/Content/CR4S/_Blueprint/FrameWork/Manager/BP_EnvironmentManager.uasset
+++ b/Content/CR4S/_Blueprint/FrameWork/Manager/BP_EnvironmentManager.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1d85ecb2cf0cad83d215be2e0627d10b43ab63d50e9f80315891d8ea28ced258
-size 140184
+oid sha256:fce778ec81e74b28dd1837fbcfda6b384be58f1772de1ecccd6780063303c324
+size 168445

--- a/Source/CR4S/Game/System/EnvironmentManager.cpp
+++ b/Source/CR4S/Game/System/EnvironmentManager.cpp
@@ -138,3 +138,27 @@ void AEnvironmentManager::SetWorldTimeMultiplier_Implementation(int32 Multiplier
 {
     TimeManager->SetWorldTimeMultiplier(Multiplier);
 }
+
+void AEnvironmentManager::AdvanceTimeOfDay(float TimeOfDay)
+{
+    if (!TimeManager) return;
+
+    const float CurrentTimeOfDay = GetCurrentTimeOfDay();
+    const int32 TotalSecondsInDay = TimeManager->GetDayCycleLength() * 60;
+
+    float DeltaTimeOfDay = TimeOfDay - CurrentTimeOfDay;
+    if (DeltaTimeOfDay < 0.0f)
+    {
+        DeltaTimeOfDay += 2400.0f;
+    }
+
+    const float TimeRatio = DeltaTimeOfDay / 2400.0f;
+    const int32 TotalAdvanceSeconds = FMath::RoundToInt(TimeRatio * TotalSecondsInDay);
+
+    const int32 MinuteOffset = TotalAdvanceSeconds / 60;
+    const int32 DayOffset = MinuteOffset / (TimeManager->GetDayCycleLength());
+
+    const int32 RemainingMinutes = MinuteOffset % (TimeManager->GetDayCycleLength());
+
+    TimeManager->ModifyTime(DayOffset, RemainingMinutes);
+}

--- a/Source/CR4S/Game/System/EnvironmentManager.h
+++ b/Source/CR4S/Game/System/EnvironmentManager.h
@@ -20,9 +20,19 @@ public:
 	void SetWeatherByName(const FString& WeatherName, float TransitionTime = 60.0f);
 	UFUNCTION(BlueprintCallable, Category = "Weather")
 	void SetWeatherBySeason(ESeasonType Season, float TransitionTime = 60.0f);
-	
 	UFUNCTION(BlueprintImplementableEvent, Category = "Time")
 	void SetSkyTime(float Time);
+
+	UFUNCTION(BlueprintImplementableEvent, BlueprintCallable, Category = "Time")
+	float GetCurrentTimeOfDay() const;
+	UFUNCTION(BlueprintImplementableEvent, BlueprintCallable, Category = "Time")
+	float GetCurrentDawnTime() const;
+	UFUNCTION(BlueprintImplementableEvent, BlueprintCallable, Category = "Time")
+	float GetCurrentDuskTime() const;
+
+
+	UFUNCTION(BlueprintCallable, Category = "Time")
+	void AdvanceTimeOfDay(float TimeOfDay);
 
 	UFUNCTION(BlueprintImplementableEvent, BlueprintCallable, Category = "Time")
 	bool IsSleepTime() const;

--- a/Source/CR4S/Game/System/WorldTimeManager.cpp
+++ b/Source/CR4S/Game/System/WorldTimeManager.cpp
@@ -58,6 +58,16 @@ void UWorldTimeManager::StartWorldTime()
 	}
 }
 
+void UWorldTimeManager::SetWorldTime(FWorldTimeData NewTimeData)
+{
+	//CurrentTimeData = NewTimeData;
+	//TotalPlayTime = NewTimeData.Day * DayCycleLength * 60 + NewTimeData.Minute * 60 + NewTimeData.Second;
+
+	//AdvanceSkyTime(CurrentTimeData.Minute, CurrentTimeData.Second);
+	//UpdateTimeWidget();
+	//OnWorldTimeUpdated.Broadcast(TotalPlayTime);
+}
+
 void UWorldTimeManager::UpdateTime()
 {
 	TotalPlayTime += 1;

--- a/Source/CR4S/Game/System/WorldTimeManager.h
+++ b/Source/CR4S/Game/System/WorldTimeManager.h
@@ -31,14 +31,14 @@ class CR4S_API UWorldTimeManager : public UWorldSubsystem
 
 
 
-#pragma region Getters & Setters & Subsystem Setup
+#pragma region Getters & Setters
 public:
 	FORCEINLINE FWorldTimeData GetCurrentTimeData() const { return CurrentTimeData; }
 	FORCEINLINE int64 GetTotalPlayTime() const { return TotalPlayTime; }
 	FORCEINLINE int32 GetDayCycleLength() const { return DayCycleLength; }
 
 	FORCEINLINE void SetWorldTimeMultiplier(int32 Multiplier) { WorldTimeMultiplier = Multiplier; }
-
+	void SetWorldTime(FWorldTimeData NewTimeData);
 
 
 #pragma endregion


### PR DESCRIPTION
EnvironmentManager에 하루 안팎으로 시간을 진행하는 AdvanceTimeOfDay(float TimeOfDay) 함수 추가

- 내부적으로 기존의 ModifyTime(int32 DayOffset, int32 MinuteOffset) 함수 활용

- ModifyTime은 초 단위 계산을 지원하지 않기 때문에, 시간 진행 시 분 단위로 반올림된 값을 사용

- 일반적으로 새벽 시간으로 이동하고자 할 때는 GetCurrentDawnTime() 등의 값을 활용할 수 있음

- 다만 GetCurrentDawnTime()은 실제 날이 밝아지기 전의 값이기 때문에, 약간의 보정값(예: +100 또는 +200 등)을 더해 사용하는 것을 권장함