### PR TITLE
[Update] Current Ammo display Widget & Refactor Widget Classes

### DIFF
--- a/Content/CR4S/_Blueprint/UI/Character/MI_AmmoIndicator.uasset
+++ b/Content/CR4S/_Blueprint/UI/Character/MI_AmmoIndicator.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bcc4808c6cb22ef9639cf59310f47809a6a262e8587845791c7c8c13c58b4c0d
+size 7611

--- a/Content/CR4S/_Blueprint/UI/Character/MI_LockOnImage.uasset
+++ b/Content/CR4S/_Blueprint/UI/Character/MI_LockOnImage.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:89c17340bcc8dd10a20cd86c1cac96eda3720bbafe61c4846141dd5ace900b24
+size 7371

--- a/Content/CR4S/_Blueprint/UI/Character/MI_RoundProgressbar.uasset
+++ b/Content/CR4S/_Blueprint/UI/Character/MI_RoundProgressbar.uasset
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ba0fab114a37b17a883d4f033f5c194cb73be57d1829e5b8bc32bd0f27a0c131
-size 9296

--- a/Content/CR4S/_Blueprint/UI/Character/WBP_AmmoWidget.uasset
+++ b/Content/CR4S/_Blueprint/UI/Character/WBP_AmmoWidget.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:96bfd932640415c37f0773152c89f6b883df17c59897ea01e59db40af244fa8b
-size 35147
+oid sha256:620b1d857fdd06e126fc40f2a122553417fc181dc6c16a5539c895ad531b33b8
+size 32878

--- a/Content/CR4S/_Blueprint/UI/Character/WBP_AmmoWidget.uasset
+++ b/Content/CR4S/_Blueprint/UI/Character/WBP_AmmoWidget.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96bfd932640415c37f0773152c89f6b883df17c59897ea01e59db40af244fa8b
+size 35147

--- a/Content/CR4S/_Blueprint/UI/Character/WBP_LockOnWdiget.uasset
+++ b/Content/CR4S/_Blueprint/UI/Character/WBP_LockOnWdiget.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cf22af146b11eb167eb2f1efca863e2c508707db30ebd49989d62d6602632693
-size 26355
+oid sha256:b81b9af22ff8803cb6a694085df51a89a67e1f1cdadcfe3d64ca5bfe91149872
+size 12707

--- a/Content/CR4S/_Blueprint/UI/Character/WBP_LockOnWidget.uasset
+++ b/Content/CR4S/_Blueprint/UI/Character/WBP_LockOnWidget.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b07f32179da3a382444482c32695fdff5836c814ed6a2e86548f1c6c81b15e05
+size 27806

--- a/Content/CR4S/_Blueprint/UI/Common/WBP_RoundProgressBar.uasset
+++ b/Content/CR4S/_Blueprint/UI/Common/WBP_RoundProgressBar.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:31f1ca3f89c0b7ed9949c011998003d3b8ec16eef4559a3983b0d3636a0dd647
+size 37344

--- a/Content/CR4S/_Blueprint/UI/InGame/WBP_DefaultInGameWidget.uasset
+++ b/Content/CR4S/_Blueprint/UI/InGame/WBP_DefaultInGameWidget.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0239f54c4cd6b448749b2af76c30cb7629338bec490024f17cb9f63a3ba54c81
-size 38914
+oid sha256:c66a0e0e6a7e6067864d439d3250a10f252dd18b64a8e8daa5fd3e99914cceb4
+size 50412

--- a/Content/CR4S/_Blueprint/UI/InGame/WBP_DefaultInGameWidget.uasset
+++ b/Content/CR4S/_Blueprint/UI/InGame/WBP_DefaultInGameWidget.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c66a0e0e6a7e6067864d439d3250a10f252dd18b64a8e8daa5fd3e99914cceb4
-size 50412
+oid sha256:8df2f65fab53689eef2e6d0777fd2d7cf93e4488d550471fdf409524941db75c
+size 43877

--- a/Content/CR4S/_Blueprint/UI/InGame/WBP_DefaultInGameWidget.uasset
+++ b/Content/CR4S/_Blueprint/UI/InGame/WBP_DefaultInGameWidget.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8df2f65fab53689eef2e6d0777fd2d7cf93e4488d550471fdf409524941db75c
-size 43877
+oid sha256:806e3d2491aa1fd05ad041242be425a45ab85f52383ec7a6f84d4abea4cd785e
+size 44151

--- a/Content/CR4S/_Blueprint/UI/UI_asset/T_RobotAimCircle.uasset
+++ b/Content/CR4S/_Blueprint/UI/UI_asset/T_RobotAimCircle.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c16188ae3ffa2f2df4ba97e77359e920383defb586d85440f83f087e34a5054a
+size 28308

--- a/Content/CR4S/_Blueprint/UI/UI_asset/T_RobotCrosshair.uasset
+++ b/Content/CR4S/_Blueprint/UI/UI_asset/T_RobotCrosshair.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d3a46f593e2098ab7629f87563328e5ef17673939e38cc5f84c2fe8924498388
+size 14920

--- a/Source/CR4S/Character/Characters/ModularRobot.cpp
+++ b/Source/CR4S/Character/Characters/ModularRobot.cpp
@@ -217,7 +217,7 @@ void AModularRobot::InitializeWidgets()
 				Status->OnEnergyChanged.AddUObject(InGameWidget,&UDefaultInGameWidget::UpdateEnergyWidget);
 				Status->OnStunChanged.AddUObject(InGameWidget,&UDefaultInGameWidget::UpdateStunWidget);
 				
-				InGameWidget->InitializeStatusWidget(Status,true);
+				InGameWidget->ToggleWidgetMode(Status,true);
 				
 				if (UCharacterEnvironmentStatusWidget* EnvironmentWidget=InGameWidget->GetEnvironmentStatusWidget())
 				{

--- a/Source/CR4S/Character/Characters/ModularRobot.cpp
+++ b/Source/CR4S/Character/Characters/ModularRobot.cpp
@@ -212,27 +212,15 @@ void AModularRobot::InitializeWidgets()
 		{
 			if (UDefaultInGameWidget* InGameWidget=CurrentHUD->GetInGameWidget())
 			{
-				Status->OnHPChanged.AddUObject(InGameWidget,&UDefaultInGameWidget::UpdateHPWidget);
-				Status->OnResourceChanged.AddUObject(InGameWidget,&UDefaultInGameWidget::UpdateResourceWidget);
-				Status->OnEnergyChanged.AddUObject(InGameWidget,&UDefaultInGameWidget::UpdateEnergyWidget);
-				Status->OnStunChanged.AddUObject(InGameWidget,&UDefaultInGameWidget::UpdateStunWidget);
-				
-				InGameWidget->ToggleWidgetMode(Status,true);
-				
-				if (UCharacterEnvironmentStatusWidget* EnvironmentWidget=InGameWidget->GetEnvironmentStatusWidget())
-				{
-					if (!CR4S_ENSURE(LogHong1,EnvironmentalStatus)) return;
-					
-					EnvironmentalStatus->OnTemperatureChanged.AddDynamic(EnvironmentWidget, &UCharacterEnvironmentStatusWidget::OnTemperatureChanged);
-					EnvironmentalStatus->OnHumidityChanged.AddDynamic(EnvironmentWidget, &UCharacterEnvironmentStatusWidget::OnHumidityChanged);
+				if (!CR4S_ENSURE(LogHong1,Status)) return;
+				InGameWidget->BindWidgetsToStatus(Status);
+				InGameWidget->ToggleWidgetMode(true);
 
-					if (!CR4S_ENSURE(LogHong1,Status)) return;
-					
-					Status->OnColdThresholdChanged.AddDynamic(EnvironmentWidget,&UCharacterEnvironmentStatusWidget::UpdateColdThreshold);
-					Status->OnHeatThresholdChanged.AddDynamic(EnvironmentWidget,&UCharacterEnvironmentStatusWidget::UpdateHeatThreshold);
-					Status->OnHumidityThresholdChanged.AddDynamic(EnvironmentWidget,&UCharacterEnvironmentStatusWidget::UpdateHumidityThreshold);
-					EnvironmentWidget->InitializeWidget(this);
-				}
+				if (!CR4S_ENSURE(LogHong1,EnvironmentalStatus)) return;
+				InGameWidget->BindEnvStatusWidgetToEnvStatus(EnvironmentalStatus);
+
+				Status->Refresh();
+				EnvironmentalStatus->Refresh();
 			}
 		}
 	}
@@ -246,24 +234,8 @@ void AModularRobot::DisconnectWidgets()
 		{
 			if (UDefaultInGameWidget* InGameWidget=CurrentHUD->GetInGameWidget())
 			{
-				Status->OnHPChanged.RemoveAll(InGameWidget);
-				Status->OnResourceChanged.RemoveAll(InGameWidget);
-				Status->OnEnergyChanged.RemoveAll(InGameWidget);
-				Status->OnStunChanged.RemoveAll(InGameWidget);
-
-				if (UCharacterEnvironmentStatusWidget* EnvironmentWidget=InGameWidget->GetEnvironmentStatusWidget())
-				{
-					if (!CR4S_ENSURE(LogHong1,EnvironmentalStatus)) return;
-					
-					EnvironmentalStatus->OnTemperatureChanged.RemoveDynamic(EnvironmentWidget, &UCharacterEnvironmentStatusWidget::OnTemperatureChanged);
-					EnvironmentalStatus->OnHumidityChanged.RemoveDynamic(EnvironmentWidget, &UCharacterEnvironmentStatusWidget::OnHumidityChanged);
-
-					if (!CR4S_ENSURE(LogHong1,Status)) return;
-					
-					Status->OnColdThresholdChanged.RemoveDynamic(EnvironmentWidget,&UCharacterEnvironmentStatusWidget::UpdateColdThreshold);
-					Status->OnHeatThresholdChanged.RemoveDynamic(EnvironmentWidget,&UCharacterEnvironmentStatusWidget::UpdateHeatThreshold);
-					Status->OnHumidityThresholdChanged.RemoveDynamic(EnvironmentWidget,&UCharacterEnvironmentStatusWidget::UpdateHumidityThreshold);
-				}
+				InGameWidget->ClearBindingsToStatus();
+				InGameWidget->ClearBindingsToEnvStatus();
 			}
 		}
 	}

--- a/Source/CR4S/Character/Characters/PlayerCharacter.cpp
+++ b/Source/CR4S/Character/Characters/PlayerCharacter.cpp
@@ -112,26 +112,16 @@ void APlayerCharacter::InitializeWidgets()
 		{
 			if (UDefaultInGameWidget* InGameWidget=CurrentHUD->GetInGameWidget())
 			{
-				Status->OnHPChanged.AddUObject(InGameWidget,&UDefaultInGameWidget::UpdateHPWidget);
-				Status->OnResourceChanged.AddUObject(InGameWidget,&UDefaultInGameWidget::UpdateResourceWidget);
-				Status->OnHungerChanged.AddUObject(InGameWidget,&UDefaultInGameWidget::UpdateHungerWidget);
-
-				InGameWidget->ToggleWidgetMode(Status,false);
+				if (!CR4S_ENSURE(LogHong1,Status)) return;
 				
-				if (UCharacterEnvironmentStatusWidget* EnvironmentWidget=InGameWidget->GetEnvironmentStatusWidget())
-				{
-					if (!CR4S_ENSURE(LogHong1,EnvironmentalStatus)) return;
-					
-					EnvironmentalStatus->OnTemperatureChanged.AddDynamic(EnvironmentWidget, &UCharacterEnvironmentStatusWidget::OnTemperatureChanged);
-					EnvironmentalStatus->OnHumidityChanged.AddDynamic(EnvironmentWidget, &UCharacterEnvironmentStatusWidget::OnHumidityChanged);
+				InGameWidget->BindWidgetsToStatus(Status);
+				InGameWidget->ToggleWidgetMode(false);
 
-					if (!CR4S_ENSURE(LogHong1,Status)) return;
-					
-					Status->OnColdThresholdChanged.AddDynamic(EnvironmentWidget,&UCharacterEnvironmentStatusWidget::UpdateColdThreshold);
-					Status->OnHeatThresholdChanged.AddDynamic(EnvironmentWidget,&UCharacterEnvironmentStatusWidget::UpdateHeatThreshold);
-					Status->OnHumidityThresholdChanged.AddDynamic(EnvironmentWidget,&UCharacterEnvironmentStatusWidget::UpdateHumidityThreshold);
-					EnvironmentWidget->InitializeWidget(this);
-				}
+				if (!CR4S_ENSURE(LogHong1,EnvironmentalStatus)) return;
+				InGameWidget->BindEnvStatusWidgetToEnvStatus(EnvironmentalStatus);
+				
+				Status->Refresh();
+				EnvironmentalStatus->Refresh();
 			}
 		}
 	}
@@ -145,24 +135,8 @@ void APlayerCharacter::DisconnectWidgets()
 		{
 			if (UDefaultInGameWidget* InGameWidget=CurrentHUD->GetInGameWidget())
 			{
-				Status->OnHPChanged.RemoveAll(InGameWidget);
-				Status->OnResourceChanged.RemoveAll(InGameWidget);
-				Status->OnHungerChanged.RemoveAll(InGameWidget);
-				InGameWidget->ToggleWidgetMode(Status,false);
-				
-				if (UCharacterEnvironmentStatusWidget* EnvironmentWidget=InGameWidget->GetEnvironmentStatusWidget())
-				{
-					if (!CR4S_ENSURE(LogHong1,EnvironmentalStatus)) return;
-					
-					EnvironmentalStatus->OnTemperatureChanged.RemoveDynamic(EnvironmentWidget, &UCharacterEnvironmentStatusWidget::OnTemperatureChanged);
-					EnvironmentalStatus->OnHumidityChanged.RemoveDynamic(EnvironmentWidget, &UCharacterEnvironmentStatusWidget::OnHumidityChanged);
-
-					if (!CR4S_ENSURE(LogHong1,Status)) return;
-					
-					Status->OnColdThresholdChanged.RemoveDynamic(EnvironmentWidget,&UCharacterEnvironmentStatusWidget::UpdateColdThreshold);
-					Status->OnHeatThresholdChanged.RemoveDynamic(EnvironmentWidget,&UCharacterEnvironmentStatusWidget::UpdateHeatThreshold);
-					Status->OnHumidityThresholdChanged.RemoveDynamic(EnvironmentWidget,&UCharacterEnvironmentStatusWidget::UpdateHumidityThreshold);
-				}
+				InGameWidget->ClearBindingsToStatus();
+				InGameWidget->ClearBindingsToEnvStatus();
 			}
 		}
 	}

--- a/Source/CR4S/Character/Characters/PlayerCharacter.cpp
+++ b/Source/CR4S/Character/Characters/PlayerCharacter.cpp
@@ -116,7 +116,7 @@ void APlayerCharacter::InitializeWidgets()
 				Status->OnResourceChanged.AddUObject(InGameWidget,&UDefaultInGameWidget::UpdateResourceWidget);
 				Status->OnHungerChanged.AddUObject(InGameWidget,&UDefaultInGameWidget::UpdateHungerWidget);
 
-				InGameWidget->InitializeStatusWidget(Status,false);
+				InGameWidget->ToggleWidgetMode(Status,false);
 				
 				if (UCharacterEnvironmentStatusWidget* EnvironmentWidget=InGameWidget->GetEnvironmentStatusWidget())
 				{
@@ -148,7 +148,7 @@ void APlayerCharacter::DisconnectWidgets()
 				Status->OnHPChanged.RemoveAll(InGameWidget);
 				Status->OnResourceChanged.RemoveAll(InGameWidget);
 				Status->OnHungerChanged.RemoveAll(InGameWidget);
-				InGameWidget->InitializeStatusWidget(Status,false);
+				InGameWidget->ToggleWidgetMode(Status,false);
 				
 				if (UCharacterEnvironmentStatusWidget* EnvironmentWidget=InGameWidget->GetEnvironmentStatusWidget())
 				{

--- a/Source/CR4S/Character/Components/BaseStatusComponent.cpp
+++ b/Source/CR4S/Character/Components/BaseStatusComponent.cpp
@@ -16,6 +16,15 @@ UBaseStatusComponent::UBaseStatusComponent()
 	// ...
 }
 
+void UBaseStatusComponent::Refresh()
+{
+	AddCurrentHP(0);
+	AddCurrentResource(0);
+	AddHeatThreshold(0);
+	AddColdThreshold(0);
+	AddHumidityThreshold(0);
+}
+
 // Called when the game starts
 void UBaseStatusComponent::BeginPlay()
 {

--- a/Source/CR4S/Character/Components/BaseStatusComponent.h
+++ b/Source/CR4S/Character/Components/BaseStatusComponent.h
@@ -23,6 +23,11 @@ class CR4S_API UBaseStatusComponent : public UActorComponent
 public:
 	// Sets default values for this component's properties
 	UBaseStatusComponent();
+
+#pragma region Refresh
+	virtual void Refresh();
+#pragma endregion
+	
 #pragma region Get
 	FORCEINLINE float GetMaxHP() const { return BaseStatus.MaxHealth; }
 	FORCEINLINE float GetCurrentHP() const { return BaseStatus.Health; }

--- a/Source/CR4S/Character/Components/EnvironmentalStatusComponent.cpp
+++ b/Source/CR4S/Character/Components/EnvironmentalStatusComponent.cpp
@@ -14,6 +14,12 @@ UEnvironmentalStatusComponent::UEnvironmentalStatusComponent()
 	PrimaryComponentTick.SetTickFunctionEnable(false);
 }
 
+void UEnvironmentalStatusComponent::Refresh()
+{
+	OnTemperatureChanged.Broadcast(CurrentTemperature);
+	OnHumidityChanged.Broadcast(CurrentHumidity);
+}
+
 void UEnvironmentalStatusComponent::BeginPlay()
 {
 	Super::BeginPlay();

--- a/Source/CR4S/Character/Components/EnvironmentalStatusComponent.h
+++ b/Source/CR4S/Character/Components/EnvironmentalStatusComponent.h
@@ -15,7 +15,9 @@ UCLASS(ClassGroup = (Custom), meta = (BlueprintSpawnableComponent))
 class CR4S_API UEnvironmentalStatusComponent : public UActorComponent
 {
 	GENERATED_BODY()
-
+	
+public:
+	void Refresh();
 protected:
 	UEnvironmentalStatusComponent();
 

--- a/Source/CR4S/Character/Components/ModularRobotStatusComponent.cpp
+++ b/Source/CR4S/Character/Components/ModularRobotStatusComponent.cpp
@@ -15,6 +15,14 @@ UModularRobotStatusComponent::UModularRobotStatusComponent()
 	PrimaryComponentTick.bCanEverTick = false;
 }
 
+void UModularRobotStatusComponent::Refresh()
+{
+	Super::Refresh();
+	AddEnergy(0);
+	AddStun(0);
+	AddWeight(0);
+}
+
 
 // Called when the game starts
 void UModularRobotStatusComponent::BeginPlay()

--- a/Source/CR4S/Character/Components/ModularRobotStatusComponent.h
+++ b/Source/CR4S/Character/Components/ModularRobotStatusComponent.h
@@ -21,6 +21,10 @@ class CR4S_API UModularRobotStatusComponent : public UBaseStatusComponent
 
 public:
 	UModularRobotStatusComponent();
+
+#pragma region Refresh
+	virtual void Refresh() override;
+#pragma endregion
 	
 #pragma region Get
 	FORCEINLINE float GetMaxEnergy() const { return RobotStatus.MaxEnergy; }

--- a/Source/CR4S/Character/Components/PlayerCharacterStatusComponent.cpp
+++ b/Source/CR4S/Character/Components/PlayerCharacterStatusComponent.cpp
@@ -13,6 +13,12 @@ UPlayerCharacterStatusComponent::UPlayerCharacterStatusComponent()
 	PrimaryComponentTick.bCanEverTick = false;
 }
 
+void UPlayerCharacterStatusComponent::Refresh()
+{
+	Super::Refresh();
+	AddCurrentHunger(0);
+}
+
 
 // Called when the game starts
 void UPlayerCharacterStatusComponent::BeginPlay()

--- a/Source/CR4S/Character/Components/PlayerCharacterStatusComponent.h
+++ b/Source/CR4S/Character/Components/PlayerCharacterStatusComponent.h
@@ -22,6 +22,11 @@ class CR4S_API UPlayerCharacterStatusComponent : public UBaseStatusComponent
 public:
 	// Sets default values for this component's properties
 	UPlayerCharacterStatusComponent();
+	
+#pragma region Refresh
+	virtual void Refresh() override;
+#pragma endregion
+	
 #pragma region Get & Set
 	FORCEINLINE float GetMaxHunger() const { return PlayerStatus.MaxHunger; }
 	FORCEINLINE float GetCurrentHunger() const { return PlayerStatus.Hunger; }

--- a/Source/CR4S/Character/Components/RobotWeaponComponent.cpp
+++ b/Source/CR4S/Character/Components/RobotWeaponComponent.cpp
@@ -8,6 +8,7 @@
 #include "Character/Weapon/RobotWeapon/BaseWeapon.h"
 #include "Character/Weapon/RobotWeapon/MeleeWeapon.h"
 #include "Character/Weapon/RobotWeapon/RangedWeapon.h"
+#include "UI/InGame/SurvivalHUD.h"
 #include "Utility/DataLoaderSubsystem.h"
 
 
@@ -151,7 +152,24 @@ void URobotWeaponComponent::EquipWeaponByTag(const FGameplayTag& Tag, const int3
 		NewWeapon->SetGameplayTag(Tag);
 		NewWeapon->Initialize(OwningCharacter);
 		Weapons[SlotIdx]=NewWeapon;
+		BindWidgetWeapon(NewWeapon,SlotIdx);
 	}
+}
+
+void URobotWeaponComponent::BindWidgetWeapon(ABaseWeapon* Target, const int32 SlotIdx)
+{
+	if (!CR4S_ENSURE(LogHong1,Target && OwningCharacter)) return;
+
+	APlayerController* PC=Cast<APlayerController>(OwningCharacter->GetController());
+	if (!CR4S_ENSURE(LogHong1,PC)) return;
+
+	ASurvivalHUD* CurrentHUD=Cast<ASurvivalHUD>(PC->GetHUD());
+	if (!CR4S_ENSURE(LogHong1,CurrentHUD)) return;
+
+	UDefaultInGameWidget* InGameWidget=Cast<UDefaultInGameWidget>(CurrentHUD->GetInGameWidget());
+	if (!CR4S_ENSURE(LogHong1,InGameWidget)) return;
+
+	InGameWidget->BindAmmoWidgetToWeapon(Target,SlotIdx);
 }
 
 void URobotWeaponComponent::BeginPlay()

--- a/Source/CR4S/Character/Components/RobotWeaponComponent.h
+++ b/Source/CR4S/Character/Components/RobotWeaponComponent.h
@@ -21,7 +21,7 @@ class CR4S_API URobotWeaponComponent : public UActorComponent
 public:
 	URobotWeaponComponent();
 	
-#pragma region Attack & Weapons
+#pragma region Attack
 public:
 	UFUNCTION(BlueprintCallable)
 	void Input_OnAttackLeftArm();
@@ -39,9 +39,12 @@ public:
 	void Input_OnAttackRightShoulder();
 	UFUNCTION(BlueprintCallable)
 	void Input_StopAttackRightShoulder();
-
+#pragma endregion
+	
+#pragma region EquipWeapon
 	UFUNCTION(BlueprintCallable)
 	void EquipWeaponByTag(const FGameplayTag& Tag, const int32 SlotIdx);
+	void BindWidgetWeapon(ABaseWeapon* Target, const int32 SlotIdx);
 #pragma endregion
 
 #pragma region Overrides

--- a/Source/CR4S/Character/UI/AmmoWidget.cpp
+++ b/Source/CR4S/Character/UI/AmmoWidget.cpp
@@ -3,6 +3,57 @@
 
 #include "AmmoWidget.h"
 
+#include "CR4S.h"
+#include "RoundProgressBar.h"
+#include "Character/Weapon/RobotWeapon/BaseWeapon.h"
+#include "Character/Weapon/RobotWeapon/RangedWeapon.h"
+
 UAmmoWidget::UAmmoWidget(const FObjectInitializer& ObjectInitializer) : Super(ObjectInitializer)
 {
 }
+
+void UAmmoWidget::NativeConstruct()
+{
+	Super::NativeConstruct();
+	AmmoProgressWidgets.Add(LeftArmCurrentAmmo);
+	AmmoProgressWidgets.Add(RightArmCurrentAmmo);
+	AmmoProgressWidgets.Add(LeftShoulderCurrentAmmo);
+	AmmoProgressWidgets.Add(RightShoulderCurrentAmmo);
+}
+
+
+void UAmmoWidget::InitializeWidgetForWeapon(ABaseWeapon* InWeapon, const int32 SlotIdx)
+{
+	if (!CR4S_ENSURE(LogHong1,InWeapon)) return;
+
+	const FGameplayTag WeaponTag=InWeapon->GetGameplayTag();
+	float InitialProgress=MaxProgress;
+	if (WeaponTag.MatchesTag(WeaponTags::Melee))
+	{
+		InitialProgress=0;
+	}
+	AmmoProgressWidgets[SlotIdx]->SetPercent(InitialProgress);
+
+	ARangedWeapon* CurrentWeapon=Cast<ARangedWeapon>(InWeapon);
+	if (!CR4S_ENSURE(LogHong1,CurrentWeapon)) return;
+
+	CurrentWeapon->OnCurrentAmmoChanged.AddLambda(
+	[WeakThis=TWeakObjectPtr<UAmmoWidget>(this),SlotIdx,this](const float InPercent)
+	{
+		if (WeakThis.IsValid())
+		{
+			WeakThis->UpdateCurrentAmmoWidget(SlotIdx,InPercent);
+		}
+	});
+}
+
+void UAmmoWidget::UpdateCurrentAmmoWidget(const int32 SlotIdx, const float Percent)
+{
+	const float FinalPercent=Percent*MaxProgress;
+
+	if (!CR4S_ENSURE(LogHong1,AmmoProgressWidgets.IsValidIndex(SlotIdx) && AmmoProgressWidgets[SlotIdx])) return;
+
+	AmmoProgressWidgets[SlotIdx]->SetPercent(FinalPercent);
+}
+
+

--- a/Source/CR4S/Character/UI/AmmoWidget.cpp
+++ b/Source/CR4S/Character/UI/AmmoWidget.cpp
@@ -1,0 +1,8 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "AmmoWidget.h"
+
+UAmmoWidget::UAmmoWidget(const FObjectInitializer& ObjectInitializer) : Super(ObjectInitializer)
+{
+}

--- a/Source/CR4S/Character/UI/AmmoWidget.h
+++ b/Source/CR4S/Character/UI/AmmoWidget.h
@@ -6,6 +6,7 @@
 #include "Blueprint/UserWidget.h"
 #include "AmmoWidget.generated.h"
 
+class ABaseWeapon;
 class URoundProgressBar;
 /**
  * 
@@ -17,8 +18,17 @@ class CR4S_API UAmmoWidget : public UUserWidget
 public:
 	UAmmoWidget(const FObjectInitializer& ObjectInitializer);
 
-
+	virtual void NativeConstruct() override;
 	
+#pragma region InitializeWidget
+	void InitializeWidgetForWeapon(ABaseWeapon* InWeapon, const int32 SlotIdx);
+#pragma endregion
+
+#pragma region UpdateWidget
+	void UpdateCurrentAmmoWidget(const int32 SlotIdx, const float Percent);
+#pragma endregion
+
+#pragma region Widgets
 protected:
 	UPROPERTY(VisibleAnywhere,BlueprintReadWrite,meta=(BindWidgetOptional))
 	TObjectPtr<URoundProgressBar> LeftArmCurrentAmmo;
@@ -28,4 +38,13 @@ protected:
 	TObjectPtr<URoundProgressBar> LeftShoulderCurrentAmmo;
 	UPROPERTY(VisibleAnywhere,BlueprintReadWrite,meta=(BindWidgetOptional))
 	TObjectPtr<URoundProgressBar> RightShoulderCurrentAmmo;
+
+	TArray<TObjectPtr<URoundProgressBar>> AmmoProgressWidgets;
+#pragma endregion
+
+#pragma region Settings
+protected:
+	UPROPERTY(EditAnywhere,BlueprintReadWrite, Category = "Setting")
+	float MaxProgress{0.2};
+#pragma endregion
 };

--- a/Source/CR4S/Character/UI/AmmoWidget.h
+++ b/Source/CR4S/Character/UI/AmmoWidget.h
@@ -1,0 +1,31 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Blueprint/UserWidget.h"
+#include "AmmoWidget.generated.h"
+
+class URoundProgressBar;
+/**
+ * 
+ */
+UCLASS()
+class CR4S_API UAmmoWidget : public UUserWidget
+{
+	GENERATED_BODY()
+public:
+	UAmmoWidget(const FObjectInitializer& ObjectInitializer);
+
+
+	
+protected:
+	UPROPERTY(VisibleAnywhere,BlueprintReadWrite,meta=(BindWidgetOptional))
+	TObjectPtr<URoundProgressBar> LeftArmCurrentAmmo;
+	UPROPERTY(VisibleAnywhere,BlueprintReadWrite,meta=(BindWidgetOptional))
+	TObjectPtr<URoundProgressBar> RightArmCurrentAmmo;
+	UPROPERTY(VisibleAnywhere,BlueprintReadWrite,meta=(BindWidgetOptional))
+	TObjectPtr<URoundProgressBar> LeftShoulderCurrentAmmo;
+	UPROPERTY(VisibleAnywhere,BlueprintReadWrite,meta=(BindWidgetOptional))
+	TObjectPtr<URoundProgressBar> RightShoulderCurrentAmmo;
+};

--- a/Source/CR4S/Character/UI/CharacterStatusWidget.cpp
+++ b/Source/CR4S/Character/UI/CharacterStatusWidget.cpp
@@ -1,4 +1,8 @@
 #include "CharacterStatusWidget.h"
+
+#include "Character/Components/BaseStatusComponent.h"
+#include "Character/Components/ModularRobotStatusComponent.h"
+#include "Character/Components/PlayerCharacterStatusComponent.h"
 #include "UI/Common/ProgressBarWidget.h"
 
 UCharacterStatusWidget::UCharacterStatusWidget(const FObjectInitializer& ObjectInitializer):Super(ObjectInitializer)
@@ -26,8 +30,23 @@ void UCharacterStatusWidget::UpdateStun(const float InPercentage)
 	Stun->SetPercent(InPercentage);
 }
 
-void UCharacterStatusWidget::ToggleWidgetMode(const bool bIsRobot)
+void UCharacterStatusWidget::ToggleWidgetMode(UBaseStatusComponent* InComponent, const bool bIsRobot)
 {
+	float Percentage=FMath::Clamp(InComponent->GetCurrentHP()/InComponent->GetMaxHP(), 0.f, 1.f);
+	UpdateHP(Percentage);
+	
+	Percentage=FMath::Clamp(InComponent->GetCurrentResource()/InComponent->GetMaxResource(), 0.f, 1.f);
+	UpdateResource(Percentage);
+	
+	if (UModularRobotStatusComponent* RobotStatusComp=Cast<UModularRobotStatusComponent>(InComponent))
+	{
+		Percentage=FMath::Clamp(RobotStatusComp->GetCurrentEnergy()/RobotStatusComp->GetMaxEnergy(), 0.f, 1.f);
+		UpdateEnergy(Percentage);
+
+		Percentage=FMath::Clamp(RobotStatusComp->GetCurrentStun()/RobotStatusComp->GetMaxStun(), 0.f, 1.f);
+		UpdateStun(Percentage);
+	}
+	
 	if (Energy)
 	{
 		Energy->SetVisibility((bIsRobot

--- a/Source/CR4S/Character/UI/CharacterStatusWidget.h
+++ b/Source/CR4S/Character/UI/CharacterStatusWidget.h
@@ -6,6 +6,7 @@
 #include "Blueprint/UserWidget.h"
 #include "CharacterStatusWidget.generated.h"
 
+class UBaseStatusComponent;
 class UProgressBarWidget;
 
 UCLASS()
@@ -31,7 +32,11 @@ public:
 	void UpdateStun(const float InPercentage);
 
 	UFUNCTION(BlueprintCallable)
-	void ToggleWidgetMode(UBaseStatusComponent* InComponent, const bool bIsRobot);
+	void ToggleWidgetMode(const bool bIsRobot);
+
+	void InitializeWidget(UBaseStatusComponent* InStatus);
+
+	void ClearBindings();
 #pragma endregion
 	
 #pragma region Widgets
@@ -48,5 +53,10 @@ protected:
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, meta=(BindWidgetOptional))
 	TObjectPtr<UProgressBarWidget> Stun;
 #pragma endregion
+
+#pragma region Cached
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly)
+	TObjectPtr<UBaseStatusComponent> CachedStatusComponent;
+#pragma	endregion
 };
 

--- a/Source/CR4S/Character/UI/CharacterStatusWidget.h
+++ b/Source/CR4S/Character/UI/CharacterStatusWidget.h
@@ -31,7 +31,7 @@ public:
 	void UpdateStun(const float InPercentage);
 
 	UFUNCTION(BlueprintCallable)
-	void ToggleWidgetMode(const bool bIsRobot);
+	void ToggleWidgetMode(UBaseStatusComponent* InComponent, const bool bIsRobot);
 #pragma endregion
 	
 #pragma region Widgets

--- a/Source/CR4S/Character/UI/LockOnWidget.cpp
+++ b/Source/CR4S/Character/UI/LockOnWidget.cpp
@@ -1,0 +1,64 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "LockOnWidget.h"
+#include "CR4S.h"
+#include "Blueprint/WidgetLayoutLibrary.h"
+#include "Character/Weapon/RobotWeapon/HomingWeapon.h"
+#include "Components/CanvasPanelSlot.h"
+#include "Components/Image.h"
+
+class UCanvasPanelSlot;
+
+ULockOnWidget::ULockOnWidget(const FObjectInitializer& ObjectInitializer):Super(ObjectInitializer)
+{
+}
+
+void ULockOnWidget::NativeConstruct()
+{
+	Super::NativeConstruct();
+	LockOnImage->SetVisibility(ESlateVisibility::Hidden);
+}
+
+void ULockOnWidget::InitializeWidgetForWeapon(AHomingWeapon* HomingWeapon)
+{
+	if (!CR4S_ENSURE(LogHong1,HomingWeapon)) return;
+	
+	HomingWeapon->OnLockOnStarted.AddDynamic(this,&ULockOnWidget::UpdateImageVisible);
+	HomingWeapon->OnLockOnCanceled.AddDynamic(this,&ULockOnWidget::UpdateImageInvisible);
+	HomingWeapon->OnLockOnFinished.AddDynamic(this,&ULockOnWidget::SetLockedOnColor);
+	HomingWeapon->OnTryingToLockOn.AddDynamic(this,&ULockOnWidget::UpdateImagePosition);
+}
+
+void ULockOnWidget::UpdateImageVisible()
+{
+	if (!CR4S_ENSURE(LogHong1,LockOnImage)) return;
+	LockOnImage->SetColorAndOpacity(FLinearColor::White);
+	LockOnImage->SetVisibility(ESlateVisibility::HitTestInvisible);
+}
+
+void ULockOnWidget::UpdateImageInvisible()
+{
+	if (!CR4S_ENSURE(LogHong1,LockOnImage)) return;
+	LockOnImage->SetVisibility(ESlateVisibility::Hidden);
+}
+
+void ULockOnWidget::SetLockedOnColor()
+{
+	if (!CR4S_ENSURE(LogHong1,LockOnImage)) return;
+	LockOnImage->SetColorAndOpacity(FLinearColor::Red);
+}
+
+void ULockOnWidget::UpdateImagePosition(const FVector2D& NewPosition)
+{
+	if (!CR4S_ENSURE(LogHong1,LockOnImage)) return;
+
+	if (UCanvasPanelSlot* ImageSlot=UWidgetLayoutLibrary::SlotAsCanvasSlot(this))
+	{
+		const float ViewportScale=UWidgetLayoutLibrary::GetViewportScale(this);
+		FVector2D LocalPosition=NewPosition/ViewportScale;
+
+		ImageSlot->SetAlignment({0.5f,0.5f});
+		ImageSlot->SetPosition(LocalPosition);
+	}
+}

--- a/Source/CR4S/Character/UI/LockOnWidget.h
+++ b/Source/CR4S/Character/UI/LockOnWidget.h
@@ -1,0 +1,40 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Blueprint/UserWidget.h"
+#include "LockOnWidget.generated.h"
+
+class AHomingWeapon;
+class UImage;
+/**
+ * 
+ */
+UCLASS()
+class CR4S_API ULockOnWidget : public UUserWidget
+{
+	GENERATED_BODY()
+
+public:
+	ULockOnWidget(const FObjectInitializer& ObjectInitializer);
+
+	virtual void NativeConstruct() override;
+
+#pragma region WidgetUpdate & Bind
+	void InitializeWidgetForWeapon(AHomingWeapon* HomingWeapon);
+	
+	UFUNCTION(BlueprintCallable)
+	void UpdateImageVisible();
+	UFUNCTION(BlueprintCallable)
+	void UpdateImageInvisible();
+	UFUNCTION(BlueprintCallable)
+	void SetLockedOnColor();
+	UFUNCTION(BlueprintCallable)
+	void UpdateImagePosition(const FVector2D& NewPosition);
+#pragma endregion
+	
+protected:
+	UPROPERTY(VisibleAnywhere, BlueprintReadWrite, meta=(BindWidgetOptional))
+	TObjectPtr<UImage> LockOnImage;
+};

--- a/Source/CR4S/Character/UI/RoundProgressBar.cpp
+++ b/Source/CR4S/Character/UI/RoundProgressBar.cpp
@@ -1,0 +1,39 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "RoundProgressBar.h"
+#include "CR4S.h"
+#include "Character/Weapon/RobotWeapon/HomingWeapon.h"
+#include "Components/Image.h"
+
+URoundProgressBar::URoundProgressBar(const FObjectInitializer& ObjectInitializer) : Super(ObjectInitializer)
+{
+	
+}
+
+void URoundProgressBar::NativeConstruct()
+{
+	Super::NativeConstruct();
+}
+
+void URoundProgressBar::SetPercent(const float InPercent)
+{
+	if (!IsValid(DynamicMaterialInstance))
+	{
+		if (!IsValid(ParentMaterial))
+		{
+			return;
+		}
+		if (!IsValid(RoundImage))
+		{
+			return;
+		}
+		DynamicMaterialInstance=UMaterialInstanceDynamic::Create(ParentMaterial,this);
+		RoundImage->SetBrushFromMaterial(DynamicMaterialInstance);
+	}
+
+	if (IsValid(DynamicMaterialInstance))
+	{
+		DynamicMaterialInstance->SetScalarParameterValue("Percent",InPercent);
+	}
+}

--- a/Source/CR4S/Character/UI/RoundProgressBar.h
+++ b/Source/CR4S/Character/UI/RoundProgressBar.h
@@ -29,6 +29,6 @@ protected:
 	TObjectPtr<UImage> RoundImage;
 	UPROPERTY(VisibleAnywhere, BlueprintReadWrite)
 	TObjectPtr<UMaterialInstanceDynamic> DynamicMaterialInstance;
-	UPROPERTY(VisibleAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	TObjectPtr<UMaterialInterface> ParentMaterial;
 };

--- a/Source/CR4S/Character/UI/RoundProgressBar.h
+++ b/Source/CR4S/Character/UI/RoundProgressBar.h
@@ -1,0 +1,34 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Blueprint/UserWidget.h"
+#include "RoundProgressBar.generated.h"
+
+class AHomingWeapon;
+class UImage;
+/**
+ * 
+ */
+UCLASS()
+class CR4S_API URoundProgressBar : public UUserWidget
+{
+	GENERATED_BODY()
+
+public:
+	URoundProgressBar(const FObjectInitializer& ObjectInitializer);
+
+	virtual void NativeConstruct() override;
+
+	UFUNCTION(BlueprintCallable)
+	void SetPercent(const float InPercent);
+	
+protected:
+	UPROPERTY(VisibleAnywhere, BlueprintReadWrite, meta=(BindWidgetOptional))
+	TObjectPtr<UImage> RoundImage;
+	UPROPERTY(VisibleAnywhere, BlueprintReadWrite)
+	TObjectPtr<UMaterialInstanceDynamic> DynamicMaterialInstance;
+	UPROPERTY(VisibleAnywhere, BlueprintReadWrite)
+	TObjectPtr<UMaterialInterface> ParentMaterial;
+};

--- a/Source/CR4S/Character/Weapon/RobotWeapon/AutomaticFireWeapon.cpp
+++ b/Source/CR4S/Character/Weapon/RobotWeapon/AutomaticFireWeapon.cpp
@@ -77,7 +77,7 @@ void AAutomaticFireWeapon::FireBulletForInterval()
 	const FRotator SpawnRotation=ShootDirection.Rotation();
 	FireBullet(MuzzleLocation, SpawnRotation);
 
-	--TypeSpecificInfo.AmmoInfo.CurrentAmmo;
+	AddCurrentAmmo(-1);
 	ApplyRecoil();
 }
 

--- a/Source/CR4S/Character/Weapon/RobotWeapon/BurstShotWeapon.cpp
+++ b/Source/CR4S/Character/Weapon/RobotWeapon/BurstShotWeapon.cpp
@@ -73,7 +73,7 @@ void ABurstShotWeapon::FireBurstShot()
 	
 	FireBullet(MuzzleLocation,SpawnRotation);
 	
-	--TypeSpecificInfo.AmmoInfo.CurrentAmmo;
+	AddCurrentAmmo(-1);
 	--BurstShotsRemaining;
 	ApplyRecoil();
 }

--- a/Source/CR4S/Character/Weapon/RobotWeapon/HomingWeapon.cpp
+++ b/Source/CR4S/Character/Weapon/RobotWeapon/HomingWeapon.cpp
@@ -89,7 +89,7 @@ void AHomingWeapon::FireHomingBullet()
 
 	FireMultiBullet(TrackingTarget.Get());
 
-	--TypeSpecificInfo.AmmoInfo.CurrentAmmo;
+	AddCurrentAmmo(-1);
 	ApplyRecoil();
 	StartAttackCooldown();
 }

--- a/Source/CR4S/Character/Weapon/RobotWeapon/HomingWeapon.cpp
+++ b/Source/CR4S/Character/Weapon/RobotWeapon/HomingWeapon.cpp
@@ -56,7 +56,7 @@ void AHomingWeapon::Initialize(AModularRobot* OwnerCharacter)
 	UDefaultInGameWidget* InGaemWidget=CurrentHUD->GetInGameWidget();
 	if (!CR4S_ENSURE(LogHong1,InGaemWidget)) return;
 
-	InGaemWidget->BindWidgetToHomingWeapon(this);
+	InGaemWidget->BindLockOnWidgetToHomingWeapon(this);
 }
 
 void AHomingWeapon::StopAttack()

--- a/Source/CR4S/Character/Weapon/RobotWeapon/MultiShotWeapon.cpp
+++ b/Source/CR4S/Character/Weapon/RobotWeapon/MultiShotWeapon.cpp
@@ -25,7 +25,7 @@ void AMultiShotWeapon::OnAttack()
 	
 	FireMultiBullet();
 	
-	--TypeSpecificInfo.AmmoInfo.CurrentAmmo;
+	AddCurrentAmmo(-1);
 	ApplyRecoil();
 	StartAttackCooldown();
 }

--- a/Source/CR4S/Character/Weapon/RobotWeapon/RangedWeapon.cpp
+++ b/Source/CR4S/Character/Weapon/RobotWeapon/RangedWeapon.cpp
@@ -154,8 +154,24 @@ void ARangedWeapon::StartReload()
 
 void ARangedWeapon::FinishReload()
 {
-	TypeSpecificInfo.AmmoInfo.CurrentAmmo=TypeSpecificInfo.AmmoInfo.MagazineCapacity;
+	SetCurrentAmmo(TypeSpecificInfo.AmmoInfo.MagazineCapacity);
 	bIsReloading=false;
 	bCanAttack=true;
 	GetWorld()->GetTimerManager().ClearTimer(ReloadTimerHandle);
 }
+
+void ARangedWeapon::AddCurrentAmmo(const int32 Amount)
+{
+	SetCurrentAmmo(TypeSpecificInfo.AmmoInfo.CurrentAmmo+Amount);
+}
+
+void ARangedWeapon::SetCurrentAmmo(const int32 NewAmount)
+{
+	const int32 MaxAmmo=TypeSpecificInfo.AmmoInfo.MagazineCapacity;
+	const int32 NewCurrentAmmo=FMath::Clamp(NewAmount,0,MaxAmmo);
+	TypeSpecificInfo.AmmoInfo.CurrentAmmo=NewCurrentAmmo;
+
+	const float Percent = (MaxAmmo>0) ? static_cast<float>(NewCurrentAmmo)/MaxAmmo : 0;
+	OnCurrentAmmoChanged.Broadcast(Percent);
+}
+

--- a/Source/CR4S/Character/Weapon/RobotWeapon/RangedWeapon.h
+++ b/Source/CR4S/Character/Weapon/RobotWeapon/RangedWeapon.h
@@ -7,7 +7,7 @@
 #include "Character/Data/WeaponData.h"
 #include "RangedWeapon.generated.h"
 
-DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnCurrentAmmoChanged, const float, InPercent);
+DECLARE_MULTICAST_DELEGATE_OneParam(FOnCurrentAmmoChanged, const float InPercent);
 
 struct FRangedWeaponData;
 class ABaseBullet;
@@ -55,6 +55,7 @@ protected:
 #pragma endregion
 
 #pragma region Delegate
+public:
 	FOnCurrentAmmoChanged OnCurrentAmmoChanged;
 #pragma endregion
 };

--- a/Source/CR4S/Character/Weapon/RobotWeapon/RangedWeapon.h
+++ b/Source/CR4S/Character/Weapon/RobotWeapon/RangedWeapon.h
@@ -7,11 +7,12 @@
 #include "Character/Data/WeaponData.h"
 #include "RangedWeapon.generated.h"
 
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnCurrentAmmoChanged, const float, InPercent);
+
 struct FRangedWeaponData;
 class ABaseBullet;
-/**
- * 
- */
+
+
 UCLASS(BlueprintType, Blueprintable)
 class CR4S_API ARangedWeapon : public ABaseWeapon
 {
@@ -37,6 +38,8 @@ protected:
 	void ApplyRecoil() const;
 	void StartReload();
 	void FinishReload();
+	void AddCurrentAmmo(const int32 Amount);
+	void SetCurrentAmmo(const int32 NewAmount);
 #pragma endregion
 	
 #pragma region TypeSpecificInfo
@@ -50,6 +53,9 @@ protected:
 	uint8 bIsReloading:1 {false};
 	FTimerHandle ReloadTimerHandle;
 #pragma endregion
-	
+
+#pragma region Delegate
+	FOnCurrentAmmoChanged OnCurrentAmmoChanged;
+#pragma endregion
 };
 

--- a/Source/CR4S/Character/Weapon/RobotWeapon/SingleShotWeapon.cpp
+++ b/Source/CR4S/Character/Weapon/RobotWeapon/SingleShotWeapon.cpp
@@ -40,7 +40,7 @@ void ASingleShotWeapon::OnAttack()
 	
 	FireBullet(MuzzleLocation,SpawnRotation);
 	
-	TypeSpecificInfo.AmmoInfo.CurrentAmmo--;
+	AddCurrentAmmo(-1);
 	ApplyRecoil();
 	StartAttackCooldown();
 }

--- a/Source/CR4S/Character/Weapon/RobotWeapon/SpreadShotWeapon.cpp
+++ b/Source/CR4S/Character/Weapon/RobotWeapon/SpreadShotWeapon.cpp
@@ -45,7 +45,7 @@ void ASpreadShotWeapon::OnAttack()
 
 		FireBullet(MuzzleLocation,SpawnRotation);
 	}
-	--TypeSpecificInfo.AmmoInfo.CurrentAmmo;
+	AddCurrentAmmo(-1);
 	ApplyRecoil();
 	StartAttackCooldown();
 }

--- a/Source/CR4S/UI/InGame/CharacterEnvironmentStatusWidget.h
+++ b/Source/CR4S/UI/InGame/CharacterEnvironmentStatusWidget.h
@@ -3,6 +3,7 @@
 #include "Blueprint/UserWidget.h"
 #include "CharacterEnvironmentStatusWidget.generated.h"
 
+class UBaseStatusComponent;
 class UEnvironmentalStatusComponent;
 class UProgressBar;
 class UTextBlock;
@@ -14,6 +15,12 @@ class CR4S_API UCharacterEnvironmentStatusWidget : public UUserWidget
 	GENERATED_BODY()
 
 public:
+	void InitializeWidget(UBaseStatusComponent* InStatus);
+	void InitializeWidget(UEnvironmentalStatusComponent* InEnvStatus);
+
+	void ClearBindingsToStatusComp();
+	void ClearBindingsToEnvStatusComp();
+	
 	UFUNCTION()
 	void OnTemperatureChanged(float NewTemperature);
 	UFUNCTION()
@@ -28,7 +35,7 @@ public:
 	void UpdateTemperatureProgressBar();
 	UFUNCTION()
 	void UpdateHumidityProgressBar();
-	bool InitializeWidget(ACharacter* NewPawn);
+	// bool InitializeWidget(ACharacter* NewPawn);
 protected:
 	virtual void NativeConstruct() override;
 	virtual void NativeTick(const FGeometry& MyGeometry, float InDeltaTime) override;
@@ -53,8 +60,11 @@ protected:
 	TWeakObjectPtr<AEnvironmentManager> EnvironmentManager;
 
 	bool bIsBoundToEnvironment = false;
-
+	
+#pragma region Cached
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly)
-	TObjectPtr<ACharacter> CurrentCharacter;
-
+	TObjectPtr<UBaseStatusComponent> CachedStatusComp;
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly)
+	TObjectPtr<UEnvironmentalStatusComponent> CachedEnvironmentalStatusComp;
+#pragma endregion
 };

--- a/Source/CR4S/UI/InGame/DefaultInGameWidget.cpp
+++ b/Source/CR4S/UI/InGame/DefaultInGameWidget.cpp
@@ -18,9 +18,10 @@ void UDefaultInGameWidget::NativeConstruct()
 	
 	LockOnImage->SetColorAndOpacity(FLinearColor::White);
 	LockOnImage->SetVisibility(ESlateVisibility::Hidden);
+	AimCircle->SetVisibility(ESlateVisibility::Hidden);
 }
 
-void UDefaultInGameWidget::InitializeStatusWidget(UBaseStatusComponent* InComponent, bool bIsRobot)
+void UDefaultInGameWidget::ToggleWidgetMode(UBaseStatusComponent* InComponent, bool bIsRobot)
 {
 	float Percentage=FMath::Clamp(InComponent->GetCurrentHP()/InComponent->GetMaxHP(), 0.f, 1.f);
 	UpdateHPWidget(Percentage);
@@ -42,6 +43,18 @@ void UDefaultInGameWidget::InitializeStatusWidget(UBaseStatusComponent* InCompon
 		UpdateStunWidget(Percentage);
 	}
 	StatusWidget->ToggleWidgetMode(bIsRobot);
+	
+	if (!CR4S_ENSURE(LogHong1,CrosshairWidget && AimCircle)) return;
+	if (bIsRobot)
+	{
+		CrosshairWidget->SetBrushFromTexture(RobotCrosshair);
+		AimCircle->SetVisibility(ESlateVisibility::HitTestInvisible);
+	}
+	else
+	{
+		CrosshairWidget->SetBrushFromTexture(DefaultCrosshair);
+		AimCircle->SetVisibility(ESlateVisibility::Hidden);
+	}
 }
 
 void UDefaultInGameWidget::BindWidgetToHomingWeapon(AHomingWeapon* HomingWeapon)

--- a/Source/CR4S/UI/InGame/DefaultInGameWidget.cpp
+++ b/Source/CR4S/UI/InGame/DefaultInGameWidget.cpp
@@ -1,10 +1,13 @@
 #include "DefaultInGameWidget.h"
 
 #include "CR4S.h"
+#include "AnimNodes/AnimNode_RandomPlayer.h"
 #include "Blueprint/WidgetLayoutLibrary.h"
 #include "Character/Components/ModularRobotStatusComponent.h"
 #include "Character/Components/PlayerCharacterStatusComponent.h"
+#include "Character/UI/AmmoWidget.h"
 #include "Character/UI/CharacterStatusWidget.h"
+#include "Character/UI/LockOnWidget.h"
 #include "Character/Weapon/RobotWeapon/HomingWeapon.h"
 #include "Components/CanvasPanelSlot.h"
 #include "Components/Image.h"
@@ -14,57 +17,46 @@
 void UDefaultInGameWidget::NativeConstruct()
 {
 	Super::NativeConstruct();
-	if (!CR4S_ENSURE(LogHong1,LockOnImage)) return;
+	if (!CR4S_ENSURE(LogHong1,LockOnWidget)) return;
 	
-	LockOnImage->SetColorAndOpacity(FLinearColor::White);
-	LockOnImage->SetVisibility(ESlateVisibility::Hidden);
 	AimCircle->SetVisibility(ESlateVisibility::Hidden);
+
+	CurrentAmmoWidgets->SetVisibility(ESlateVisibility::Hidden);
 }
 
 void UDefaultInGameWidget::ToggleWidgetMode(UBaseStatusComponent* InComponent, bool bIsRobot)
 {
-	float Percentage=FMath::Clamp(InComponent->GetCurrentHP()/InComponent->GetMaxHP(), 0.f, 1.f);
-	UpdateHPWidget(Percentage);
-	
-	Percentage=FMath::Clamp(InComponent->GetCurrentResource()/InComponent->GetMaxResource(), 0.f, 1.f);
-	UpdateResourceWidget(Percentage);
-
 	if (UPlayerCharacterStatusComponent* PlayerStatusComp=Cast<UPlayerCharacterStatusComponent>(InComponent))
 	{
-		Percentage=FMath::Clamp(PlayerStatusComp->GetCurrentHunger()/PlayerStatusComp->GetMaxHunger(), 0.f, 1.f);
+		const float Percentage=FMath::Clamp(PlayerStatusComp->GetCurrentHunger()/PlayerStatusComp->GetMaxHunger(), 0.f, 1.f);
 		UpdateHungerWidget(Percentage);
 	}
-	if (UModularRobotStatusComponent* RobotStatusComp=Cast<UModularRobotStatusComponent>(InComponent))
-	{
-		Percentage=FMath::Clamp(RobotStatusComp->GetCurrentEnergy()/RobotStatusComp->GetMaxEnergy(), 0.f, 1.f);
-		UpdateEnergyWidget(Percentage);
-
-		Percentage=FMath::Clamp(RobotStatusComp->GetCurrentStun()/RobotStatusComp->GetMaxStun(), 0.f, 1.f);
-		UpdateStunWidget(Percentage);
-	}
-	StatusWidget->ToggleWidgetMode(bIsRobot);
+	
+	StatusWidget->ToggleWidgetMode(InComponent,bIsRobot);
 	
 	if (!CR4S_ENSURE(LogHong1,CrosshairWidget && AimCircle)) return;
+	
 	if (bIsRobot)
 	{
 		CrosshairWidget->SetBrushFromTexture(RobotCrosshair);
 		AimCircle->SetVisibility(ESlateVisibility::HitTestInvisible);
+		CurrentAmmoWidgets->SetVisibility(ESlateVisibility::HitTestInvisible);
 	}
 	else
 	{
 		CrosshairWidget->SetBrushFromTexture(DefaultCrosshair);
 		AimCircle->SetVisibility(ESlateVisibility::Hidden);
+		CurrentAmmoWidgets->SetVisibility(ESlateVisibility::Hidden);
 	}
+
+	if (!CR4S_ENSURE(LogHong1,CurrentAmmoWidgets)) return;
 }
 
 void UDefaultInGameWidget::BindWidgetToHomingWeapon(AHomingWeapon* HomingWeapon)
 {
-	if (!CR4S_ENSURE(LogHong1,HomingWeapon)) return;
+	if (!CR4S_ENSURE(LogHong1,HomingWeapon && LockOnWidget)) return;
 
-	HomingWeapon->OnLockOnStarted.AddDynamic(this,&UDefaultInGameWidget::UpdateImageVisible);
-	HomingWeapon->OnLockOnCanceled.AddDynamic(this,&UDefaultInGameWidget::UpdateImageInvisible);
-	HomingWeapon->OnLockOnFinished.AddDynamic(this,&UDefaultInGameWidget::SetLockedOnColor);
-	HomingWeapon->OnTryingToLockOn.AddDynamic(this,&UDefaultInGameWidget::UpdateImagePosition);
+	LockOnWidget->InitializeWidgetForWeapon(HomingWeapon);	
 }
 
 void UDefaultInGameWidget::UpdateHPWidget(const float InPercentage)
@@ -117,38 +109,5 @@ void UDefaultInGameWidget::UpdateTimeWidget(FWorldTimeData CurrentTimeData)
 	}
 }
 
-void UDefaultInGameWidget::UpdateImageVisible()
-{
-	if (!CR4S_ENSURE(LogHong1,LockOnImage)) return;
-	LockOnImage->SetColorAndOpacity(FLinearColor::White);
-	LockOnImage->SetVisibility(ESlateVisibility::HitTestInvisible);
-}
-
-void UDefaultInGameWidget::UpdateImageInvisible()
-{
-	if (!CR4S_ENSURE(LogHong1,LockOnImage)) return;
-	LockOnImage->SetVisibility(ESlateVisibility::Hidden);
-}
-
-void UDefaultInGameWidget::SetLockedOnColor()
-{
-	if (!CR4S_ENSURE(LogHong1,LockOnImage)) return;
-	LockOnImage->SetColorAndOpacity(FLinearColor::Red);
-}
-
-void UDefaultInGameWidget::UpdateImagePosition(const FVector2D& NewPosition)
-{
-	if (!CR4S_ENSURE(LogHong1,LockOnImage)) return;
-
-	if (UCanvasPanelSlot* ImageSlot=UWidgetLayoutLibrary::SlotAsCanvasSlot(LockOnImage))
-	{
-		const float ViewportScale=UWidgetLayoutLibrary::GetViewportScale(this);
-		FVector2D LocalPosition=NewPosition/ViewportScale;
-
-		ImageSlot->SetAlignment({0.5f,0.5f});
-		ImageSlot->SetPosition(LocalPosition);
-		
-	}
-}
 
 

--- a/Source/CR4S/UI/InGame/DefaultInGameWidget.h
+++ b/Source/CR4S/UI/InGame/DefaultInGameWidget.h
@@ -28,7 +28,7 @@ public:
 	
 #pragma region Initialize
 public:
-	void InitializeStatusWidget(UBaseStatusComponent* InComponent, bool bIsRobot);
+	void ToggleWidgetMode(UBaseStatusComponent* InComponent, bool bIsRobot);
 	UFUNCTION(BlueprintCallable)
 	void BindWidgetToHomingWeapon(AHomingWeapon* HomingWeapon);
 #pragma endregion
@@ -53,6 +53,14 @@ public:
 
 #pragma endregion
 
+#pragma region CrosshairImage
+protected:
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category=Crosshair)
+	TObjectPtr<UTexture2D> DefaultCrosshair;
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category=Crosshair)
+	TObjectPtr<UTexture2D> RobotCrosshair;
+#pragma endregion 
+	
 #pragma region Widgets
 protected:
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, meta=(BindWidgetOptional))
@@ -65,6 +73,10 @@ protected:
 	TObjectPtr<UCharacterEnvironmentStatusWidget> EnvironmentStatusWidget;
 	UPROPERTY(VisibleAnywhere, BlueprintReadWrite, meta=(BindWidgetOptional))
 	TObjectPtr<UImage> LockOnImage;
+	UPROPERTY(VisibleAnywhere, BlueprintReadWrite, meta=(BindWidgetOptional))
+	TObjectPtr<UImage> CrosshairWidget;
+	UPROPERTY(VisibleAnywhere, BlueprintReadWrite, meta=(BindWidgetOptional))
+	TObjectPtr<UImage> AimCircle;
 #pragma endregion
 	
 };

--- a/Source/CR4S/UI/InGame/DefaultInGameWidget.h
+++ b/Source/CR4S/UI/InGame/DefaultInGameWidget.h
@@ -4,6 +4,8 @@
 #include "Game/System/WorldTimeManager.h"
 #include "DefaultInGameWidget.generated.h"
 
+class UAmmoWidget;
+class URoundProgressBar;
 class UImage;
 class AHomingWeapon;
 class ULockOnWidget;
@@ -42,14 +44,6 @@ public:
 	void UpdateHungerWidget(const float InPercentage);
 	void UpdateTimeWidget(FWorldTimeData CurrentTimeData);
 
-	UFUNCTION(BlueprintCallable)
-	void UpdateImageVisible();
-	UFUNCTION(BlueprintCallable)
-	void UpdateImageInvisible();
-	UFUNCTION(BlueprintCallable)
-	void SetLockedOnColor();
-	UFUNCTION(BlueprintCallable)
-	void UpdateImagePosition(const FVector2D& NewPosition);
 
 #pragma endregion
 
@@ -66,17 +60,19 @@ protected:
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, meta=(BindWidgetOptional))
 	TObjectPtr<UCharacterStatusWidget> StatusWidget;
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, meta=(BindWidgetOptional))
-	TObjectPtr< UProgressBarWidget> HungerWidget;
+	TObjectPtr<UProgressBarWidget> HungerWidget;
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, meta = (BindWidgetOptional))
 	TObjectPtr<UTimeDisplayWidget> TimeDisplayWidget;
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, meta = (BindWidgetOptional))
 	TObjectPtr<UCharacterEnvironmentStatusWidget> EnvironmentStatusWidget;
 	UPROPERTY(VisibleAnywhere, BlueprintReadWrite, meta=(BindWidgetOptional))
-	TObjectPtr<UImage> LockOnImage;
-	UPROPERTY(VisibleAnywhere, BlueprintReadWrite, meta=(BindWidgetOptional))
 	TObjectPtr<UImage> CrosshairWidget;
 	UPROPERTY(VisibleAnywhere, BlueprintReadWrite, meta=(BindWidgetOptional))
 	TObjectPtr<UImage> AimCircle;
+	UPROPERTY(VisibleAnywhere, BlueprintReadWrite, meta=(BindWidgetOptional))
+	TObjectPtr<ULockOnWidget> LockOnWidget;
+	UPROPERTY(VisibleAnywhere, BlueprintReadWrite, meta=(BindWidgetOptional))
+	TObjectPtr<UAmmoWidget> CurrentAmmoWidgets;
 #pragma endregion
 	
 };

--- a/Source/CR4S/UI/InGame/DefaultInGameWidget.h
+++ b/Source/CR4S/UI/InGame/DefaultInGameWidget.h
@@ -4,6 +4,8 @@
 #include "Game/System/WorldTimeManager.h"
 #include "DefaultInGameWidget.generated.h"
 
+class UEnvironmentalStatusComponent;
+class ABaseWeapon;
 class UAmmoWidget;
 class URoundProgressBar;
 class UImage;
@@ -28,19 +30,24 @@ public:
 	FORCEINLINE UCharacterEnvironmentStatusWidget* GetEnvironmentStatusWidget() { return EnvironmentStatusWidget; }
 #pragma endregion
 	
-#pragma region Initialize
+#pragma region Bind & Unbind
 public:
-	void ToggleWidgetMode(UBaseStatusComponent* InComponent, bool bIsRobot);
+	void ToggleWidgetMode(const bool bIsRobot);
 	UFUNCTION(BlueprintCallable)
-	void BindWidgetToHomingWeapon(AHomingWeapon* HomingWeapon);
+	void BindLockOnWidgetToHomingWeapon(AHomingWeapon* HomingWeapon);
+	UFUNCTION(BlueprintCallable)
+	void BindAmmoWidgetToWeapon(ABaseWeapon* InWeapon, const int32 SlotIdx);
+
+	void BindWidgetsToStatus(UBaseStatusComponent* InStatus);
+	
+	void BindEnvStatusWidgetToEnvStatus(UEnvironmentalStatusComponent* InStatus);
+
+	void ClearBindingsToStatus();
+	void ClearBindingsToEnvStatus();
 #pragma endregion
 	
 #pragma region UpdateWidget
 public:
-	void UpdateHPWidget(const float InPercentage);
-	void UpdateResourceWidget(const float InPercentage);
-	void UpdateEnergyWidget(const float InPercentage);
-	void UpdateStunWidget(const float InPercentage);
 	void UpdateHungerWidget(const float InPercentage);
 	void UpdateTimeWidget(FWorldTimeData CurrentTimeData);
 
@@ -74,5 +81,4 @@ protected:
 	UPROPERTY(VisibleAnywhere, BlueprintReadWrite, meta=(BindWidgetOptional))
 	TObjectPtr<UAmmoWidget> CurrentAmmoWidgets;
 #pragma endregion
-	
 };


### PR DESCRIPTION
### 남은 탄약 표시용 UI 추가
- 근접 무기 장착시 표시 X
- 원거리 무기 장착시 해당 무기의 델리게이트에 연동 (RobotWeaponComponent에서 바인딩)
- 발사 과정에서 탄약이 소모될 때마다 탄약 소모 델리게이트 브로드캐스팅하여 업데이트
- WBP_AmmoWdiget의 MaxProgress 값 조절하여 원형 프로그레스바의 최대 진행률 설정 가능 (현재 0.2 기준)
### Widget 클래스 리팩터링
- DefaultInGameWidget에서 진행하던 각종 델리게이트 바인딩 작업 모두 해당하는 위젯 클래스 내부로 이동
- 간단한 위젯들의 경우에만 DefaultInGameWidget에서 그대로 진행 
   ex) 배고픔 UI
- DefaultInGameWidget에 위젯 델리게이트 바인딩용 함수 추가 : 단순 멤버 변수 함수 호출
- UI 업데이트 주체가 되는 Widget 클래스 내부에 델리게이트 바인딩용 함수 추가 (Initialize)
- 캐릭터, 로봇 전환 간에 바인딩 해제되어야 하는 델리게이트 위주로 ClearBindings() 함수 추가
### 캐릭터, 로봇 전환시 HUD 구성 변경
- 크로스헤어 이미지 변경
- 크로스헤어 주변 원형 UI 로봇 탑승시 보이도록 설정
- 남은 탄약 표시용 UI도 로봇 탑승시 보이도록 설정