### PR TITLE
[Refactor] Stabilized the homing weapon's state machine, improved the input system via modular IMC separation, and re-architected the UI to support multi-target lock-on

### DIFF
--- a/Config/DefaultEngine.ini
+++ b/Config/DefaultEngine.ini
@@ -184,6 +184,9 @@ DefaultBaseSoundMix=/Game/CR4S/_Sounds/SCM_CR4S.SCM_CR4S
 +PropertyRedirects=(OldName="/Script/CR4S.BoosterPartsInfo.ResourceCost",NewName="/Script/CR4S.BoosterPartsInfo.ResourceConsumption")
 +PropertyRedirects=(OldName="/Script/CR4S.RobotSettings.DashStrength",NewName="/Script/CR4S.RobotSettings.BoosterStrength")
 +PropertyRedirects=(OldName="/Script/CR4S.BoosterPartsInfo.Power",NewName="/Script/CR4S.BoosterPartsInfo.BoosterStrength")
++PropertyRedirects=(OldName="/Script/CR4S.ModularRobotStats.MaxArmLoad",NewName="/Script/CR4S.ModularRobotStats.MaxArmMountWeight")
++PropertyRedirects=(OldName="/Script/CR4S.ModularRobotStats.MaxArmCapacity",NewName="/Script/CR4S.ModularRobotStats.MaxArmMountWeight")
++PropertyRedirects=(OldName="/Script/CR4S.ModularRobotStats.CurrentArmLoad",NewName="/Script/CR4S.ModularRobotStats.CurrentArmMountWeight")
 
 [/Script/Engine.GameEngine]
 +NetDriverDefinitions=(DefName="GameNetDriver",DriverClassName="OnlineSubsystemSteam.SteamNetDriver",DriverClassNameFallback="OnlineSubsystemUtils.IpNetDriver")

--- a/Content/CR4S/Inputs/Robot/IA_Dash.uasset
+++ b/Content/CR4S/Inputs/Robot/IA_Dash.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bdaa34cd6f60cb76c2c1ecb82a00399c52acd913de04a39de65017585b8b9075
+size 1376

--- a/Content/CR4S/Inputs/Robot/IA_HorizontalDash.uasset
+++ b/Content/CR4S/Inputs/Robot/IA_HorizontalDash.uasset
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cf4e132cefae43e1d7a33801afeb93ac64aa6b67a0299234fc3a2d614bed0966
-size 1426

--- a/Content/CR4S/Inputs/Robot/IA_VerticalDash.uasset
+++ b/Content/CR4S/Inputs/Robot/IA_VerticalDash.uasset
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:894954bf15859fc06e5455fede8e4589b6894aa49516e0ece6aae5e855099097
-size 1612

--- a/Content/CR4S/Inputs/Robot/IMC_Robot.uasset
+++ b/Content/CR4S/Inputs/Robot/IMC_Robot.uasset
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d50d4dd2d2246f82af0c3d502134272ed43fc144562ca1aed12a29975ed05d51
-size 12533

--- a/Content/CR4S/Inputs/Robot/IMC_RobotMovement.uasset
+++ b/Content/CR4S/Inputs/Robot/IMC_RobotMovement.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7bb9585bb9e35c7190e8e3f4e1752e395e373ee4e86886bd3d7c3b44f725846d
+size 10997

--- a/Content/CR4S/Inputs/Robot/IMC_RobotUtility.uasset
+++ b/Content/CR4S/Inputs/Robot/IMC_RobotUtility.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ad0b8f947417d4d39df7120ed6c5c2399a3729ed59fa61f33152e1ff2feac3ed
+size 2852

--- a/Content/CR4S/_Blueprint/Character/Robot/BP_Robot.uasset
+++ b/Content/CR4S/_Blueprint/Character/Robot/BP_Robot.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2f9a206d90382facec81a0cf08724e65e49eab42a4be56d1c9fcbec43773bca5
-size 291993
+oid sha256:1c0aad8202e63a4e5646265a923b46b8f1b8a23afc2dfab6a6ed4410d04d2ee6
+size 252692

--- a/Content/CR4S/_Blueprint/Character/Robot/BP_Robot.uasset
+++ b/Content/CR4S/_Blueprint/Character/Robot/BP_Robot.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1c0aad8202e63a4e5646265a923b46b8f1b8a23afc2dfab6a6ed4410d04d2ee6
-size 252692
+oid sha256:832686d9c6d071cfbe5563bee1499d270aee2a7e6c584260769707285ce48f2b
+size 252703

--- a/Content/CR4S/_Blueprint/UI/InGame/WBP_DefaultInGameWidget.uasset
+++ b/Content/CR4S/_Blueprint/UI/InGame/WBP_DefaultInGameWidget.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:806e3d2491aa1fd05ad041242be425a45ab85f52383ec7a6f84d4abea4cd785e
-size 44151
+oid sha256:4b417e6daffa2d6a299b4feda32b05bcc4232a26a5b67748c954602ba3b98fbc
+size 47533

--- a/Source/CR4S/Character/Characters/ModularRobot.cpp
+++ b/Source/CR4S/Character/Characters/ModularRobot.cpp
@@ -111,6 +111,11 @@ void AModularRobot::EquipCoreParts(const FGameplayTag& Tag)
 	const bool bSucceed = Loader->LoadCorePartsDataByTag(Tag, CoreInfo);
 	if (!CR4S_ENSURE(LogHong1,bSucceed)) return;
 
+	if (CoreTag.IsValid())
+	{
+		UnequipCoreParts();
+	}
+	
 	CoreTag=Tag;
 	
 	Status->AddAttackPower(CoreInfo.AttackPower);
@@ -133,6 +138,11 @@ void AModularRobot::EquipBodyParts(const FGameplayTag& Tag)
 	const bool bSucceed = Loader->LoadBodyPartsDataByTag(Tag, BodyInfo);
 	if (!CR4S_ENSURE(LogHong1,bSucceed)) return;
 
+	if (BodyTag.IsValid())
+	{
+		UnequipBodyParts();
+	}
+	
 	BodyTag=Tag;
 
 	Status->AddMaxHP(BodyInfo.MaxHealth);
@@ -160,6 +170,11 @@ void AModularRobot::EquipArmParts(const FGameplayTag& Tag)
 	FArmPartsInfo ArmInfo;
 	const bool bSucceed = Loader->LoadArmPartsDataByTag(Tag, ArmInfo);
 	if (!CR4S_ENSURE(LogHong1,bSucceed)) return;
+
+	if (ArmTag.IsValid())
+	{
+		UnequipArmParts();
+	}
 	
 	ArmTag=Tag;
 
@@ -167,6 +182,7 @@ void AModularRobot::EquipArmParts(const FGameplayTag& Tag)
 	Status->AddCurrentHP(ArmInfo.MaxHealth);
 	Status->AddArmor(ArmInfo.Armor);
 	Status->AddWeight(ArmInfo.Weight);
+	Status->AddMaxArmMountWeight(ArmInfo.MaxArmLoad);
 	Status->ApplyRecoilModifier(ArmInfo.RecoilModifier);
 	Status->ApplyMeleeDamageModifier(ArmInfo.MeleeDamageModifier);
 	
@@ -183,7 +199,11 @@ void AModularRobot::EquipLegParts(const FGameplayTag& Tag)
 	const bool bSucceed = Loader->LoadLegPartsDataByTag(Tag, LegInfo);
 	if (!CR4S_ENSURE(LogHong1,bSucceed)) return;
 
-
+	if (LegTag.IsValid())
+	{
+		UnequipLegParts();
+	}
+	
 	Status->AddMaxWeight(LegInfo.MaxTotalWeight);
 	
 	LegTag=Tag;
@@ -217,6 +237,11 @@ void AModularRobot::EquipBoosterParts(const FGameplayTag& Tag)
 	const bool bSuccessed = Loader->LoadBoosterPartsDataByTag(Tag, BoosterInfo);
 	if (!CR4S_ENSURE(LogHong1,bSuccessed)) return;
 
+	if (BoosterTag.IsValid())
+	{
+		UnequipBoosterParts();
+	}
+	
 	BoosterTag=Tag;
 
 	RobotSettings.BoosterStrength=BoosterInfo.BoosterStrength;
@@ -290,6 +315,7 @@ void AModularRobot::UnequipArmParts()
 	Status->AddCurrentHP(-(ArmInfo.MaxHealth));
 	Status->AddArmor(-(ArmInfo.Armor));
 	Status->AddWeight(-(ArmInfo.Weight));
+	Status->AddMaxArmMountWeight(-(ArmInfo.MaxArmLoad));
 	Status->RevertRecoilModifier(ArmInfo.RecoilModifier);
 	Status->RevertMeleeDamageModifier(ArmInfo.MeleeDamageModifier);
 }

--- a/Source/CR4S/Character/Characters/ModularRobot.cpp
+++ b/Source/CR4S/Character/Characters/ModularRobot.cpp
@@ -600,9 +600,10 @@ void AModularRobot::DisconnectWidgets() const
 		{
 			if (UDefaultInGameWidget* InGameWidget=CurrentHUD->GetInGameWidget())
 			{
-				InGameWidget->ClearBindingsToStatus();
-				InGameWidget->ClearBindingsToEnvStatus();
-				InGameWidget->ClearAmmoWidgetToWeapon();
+				InGameWidget->UnbindStatusFromUI();
+				InGameWidget->UnbindEnvStatusFromUI();
+				InGameWidget->UnbindWeaponFromUI();
+				InGameWidget->UnbindAllHomingWeaponFromUI();
 			}
 		}
 	}

--- a/Source/CR4S/Character/Characters/ModularRobot.cpp
+++ b/Source/CR4S/Character/Characters/ModularRobot.cpp
@@ -578,15 +578,15 @@ void AModularRobot::InitializeWidgets() const
 				if (!CR4S_ENSURE(LogHong1,Status)) return;
 				InGameWidget->BindWidgetsToStatus(Status);
 				InGameWidget->ToggleWidgetMode(true);
+				Status->Refresh();
 
 				if (!CR4S_ENSURE(LogHong1,EnvironmentalStatus)) return;
 				InGameWidget->BindEnvStatusWidgetToEnvStatus(EnvironmentalStatus);
-
-				Status->Refresh();
 				EnvironmentalStatus->Refresh();
 
 				if (!CR4S_ENSURE(LogHong1,WeaponManager)) return;
 				WeaponManager->BindWidgetWeapon();
+				WeaponManager->RefreshWeaponUI();
 			}
 		}
 	}

--- a/Source/CR4S/Character/Characters/ModularRobot.cpp
+++ b/Source/CR4S/Character/Characters/ModularRobot.cpp
@@ -232,7 +232,7 @@ void AModularRobot::EquipBoosterParts(const FGameplayTag& Tag)
 {
 	UDataLoaderSubsystem* Loader=GetDataLoaderSubsystem();
 	if (!CR4S_ENSURE(LogHong1,Loader)) return;
-
+	
 	FBoosterPartsInfo BoosterInfo;
 	const bool bSuccessed = Loader->LoadBoosterPartsDataByTag(Tag, BoosterInfo);
 	if (!CR4S_ENSURE(LogHong1,bSuccessed)) return;
@@ -584,6 +584,9 @@ void AModularRobot::InitializeWidgets() const
 
 				Status->Refresh();
 				EnvironmentalStatus->Refresh();
+
+				if (!CR4S_ENSURE(LogHong1,WeaponManager)) return;
+				WeaponManager->BindWidgetWeapon();
 			}
 		}
 	}
@@ -599,6 +602,7 @@ void AModularRobot::DisconnectWidgets() const
 			{
 				InGameWidget->ClearBindingsToStatus();
 				InGameWidget->ClearBindingsToEnvStatus();
+				InGameWidget->ClearAmmoWidgetToWeapon();
 			}
 		}
 	}

--- a/Source/CR4S/Character/Characters/ModularRobot.h
+++ b/Source/CR4S/Character/Characters/ModularRobot.h
@@ -37,6 +37,11 @@ public:
 	// Sets default values for this character's properties
 	AModularRobot();
 
+#pragma region InputEnable
+	void SetInputEnable(const bool bEnableInput) const;
+	void SetMovementInputEnable(const bool bEnableMovementInput) const;
+#pragma endregion
+	
 #pragma region PartsEquip
 	UFUNCTION(BlueprintCallable)
 	void EquipCoreParts(const FGameplayTag& Tag);
@@ -65,13 +70,13 @@ public:
 	
 #pragma region Stun
 	virtual void TakeStun_Implementation(const float StunAmount) override;
-	void SetInputEnable(const bool bEnableInput);
 #pragma endregion
 	
 #pragma region Get
 	FORCEINLINE APlayerCharacter* GetMountedCharacter() const { return MountedCharacter; }
 	FORCEINLINE bool IsRobotActive() const { return Status->IsRobotActive(); }
 	FORCEINLINE float GetRecoilModifier() const { return Status->GetRecoilModifier(); }
+	FORCEINLINE UModularRobotStatusComponent* GetStatusComponent() const { return Status; }
 #pragma endregion
 
 #pragma region Death
@@ -131,33 +136,34 @@ protected:
 
 #pragma region InputActions
 protected:
-	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Settings|Modular Robot", Meta = (DisplayThumbnail = false))
-	TObjectPtr<UInputMappingContext> InputMappingContext;
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "IMC | Movement", Meta = (DisplayThumbnail = false))
+	TObjectPtr<UInputMappingContext> MovementMappingContext;
 
-	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Settings|Modular Robot", Meta = (DisplayThumbnail = false))
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "IMC | Movement", Meta = (DisplayThumbnail = false))
 	TObjectPtr<UInputAction> LookAction;
 
-	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Settings|Modular Robot", Meta = (DisplayThumbnail = false))
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "IMC | Movement", Meta = (DisplayThumbnail = false))
 	TObjectPtr<UInputAction> MoveAction;
 
-	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Settings|Modular Robot", Meta = (DisplayThumbnail = false))
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "IMC | Movement", Meta = (DisplayThumbnail = false))
 	TObjectPtr<UInputAction> JumpAction;
 
-	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Settings|Modular Robot", Meta = (DisplayThumbnail = false))
-	TObjectPtr<UInputAction> HorizontalDashAction;
-
-	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Settings|Modular Robot", Meta = (DisplayThumbnail = false))
-	TObjectPtr<UInputAction> InteractionAction;
-
-	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Settings|Modular Robot", Meta = (DisplayThumbnail = false))
-	TObjectPtr<UInputAction> Attack1Action;
-	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Settings|Modular Robot", Meta = (DisplayThumbnail = false))
-	TObjectPtr<UInputAction> Attack2Action;
-	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Settings|Modular Robot", Meta = (DisplayThumbnail = false))
-	TObjectPtr<UInputAction> Attack3Action;
-	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Settings|Modular Robot", Meta = (DisplayThumbnail = false))
-	TObjectPtr<UInputAction> Attack4Action;
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "IMC | Movement", Meta = (DisplayThumbnail = false))
+	TObjectPtr<UInputAction> DashAction;
 	
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "IMC | Movement", Meta = (DisplayThumbnail = false))
+	TObjectPtr<UInputAction> Attack1Action;
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "IMC | Movement", Meta = (DisplayThumbnail = false))
+	TObjectPtr<UInputAction> Attack2Action;
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "IMC | Movement", Meta = (DisplayThumbnail = false))
+	TObjectPtr<UInputAction> Attack3Action;
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "IMC | Movement", Meta = (DisplayThumbnail = false))
+	TObjectPtr<UInputAction> Attack4Action;
+
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "IMC | Utility", Meta = (DisplayThumbnail = false))
+	TObjectPtr<UInputMappingContext> UtilityMappingContext;
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "IMC | Utility", Meta = (DisplayThumbnail = false))
+	TObjectPtr<UInputAction> InteractionAction;
 #pragma endregion
 
 #pragma region Settings

--- a/Source/CR4S/Character/Characters/PlayerCharacter.cpp
+++ b/Source/CR4S/Character/Characters/PlayerCharacter.cpp
@@ -135,8 +135,8 @@ void APlayerCharacter::DisconnectWidgets()
 		{
 			if (UDefaultInGameWidget* InGameWidget=CurrentHUD->GetInGameWidget())
 			{
-				InGameWidget->ClearBindingsToStatus();
-				InGameWidget->ClearBindingsToEnvStatus();
+				InGameWidget->UnbindStatusFromUI();
+				InGameWidget->UnbindEnvStatusFromUI();
 			}
 		}
 	}

--- a/Source/CR4S/Character/Components/ModularRobotStatusComponent.cpp
+++ b/Source/CR4S/Character/Components/ModularRobotStatusComponent.cpp
@@ -16,12 +16,14 @@ UModularRobotStatusComponent::UModularRobotStatusComponent()
 	PrimaryComponentTick.bCanEverTick = false;
 }
 
-bool UModularRobotStatusComponent::CheckWeightCapacity(const float AdditionalWeight) const
+void UModularRobotStatusComponent::CheckTotalWeightCapacity()
 {
-	const float TotalWeight=AdditionalWeight+RobotStatus.Weight;
-	if (TotalWeight>RobotStatus.MaxWeight) return false;
+	bExceedsTotalWeightLimit = (RobotStatus.Weight>RobotStatus.MaxWeight) ? true : false;
+}
 
-	return false;
+void UModularRobotStatusComponent::CheckArmCapacity()
+{
+	bExceedsArmWeightLimit = (RobotStatus.CurrentArmMountWeight>RobotStatus.MaxArmMountWeight) ? true : false;
 }
 
 void UModularRobotStatusComponent::Refresh()
@@ -202,12 +204,28 @@ void UModularRobotStatusComponent::AddMaxWeight(const float InAmount)
 {
 	RobotStatus.MaxWeight+=InAmount;
 	OnMaxWeightChanged.Broadcast(RobotStatus.MaxWeight);
+	CheckTotalWeightCapacity();
 }
 
 void UModularRobotStatusComponent::AddWeight(const float InAmount)
 {
 	RobotStatus.Weight+=InAmount;
 	OnWeightChanged.Broadcast(RobotStatus.Weight);
+	CheckTotalWeightCapacity();
+}
+
+void UModularRobotStatusComponent::AddMaxArmMountWeight(const float InAmount)
+{
+	RobotStatus.MaxArmMountWeight+=InAmount;
+	OnMaxArmLoadChanged.Broadcast(RobotStatus.MaxArmMountWeight);
+	CheckArmCapacity();
+}
+
+void UModularRobotStatusComponent::AddCurrentArmMountWeight(const float InAmount)
+{
+	RobotStatus.CurrentArmMountWeight+=InAmount;
+	OnArmLoadChanged.Broadcast(RobotStatus.CurrentArmMountWeight);
+	CheckArmCapacity();
 }
 
 void UModularRobotStatusComponent::ApplyEnergyEfficiency(const float Modifier)

--- a/Source/CR4S/Character/Components/ModularRobotStatusComponent.h
+++ b/Source/CR4S/Character/Components/ModularRobotStatusComponent.h
@@ -11,6 +11,8 @@ DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnEnergyChangedDelegate, float, Per
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnStunChangedDelegate, float, Percent);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnWeightChangedDelegate, float, NewValue);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnMaxWeightChangedDelegate, float, NewValue);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnArmLoadChangedDelegate, float, NewValue);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnMaxArmLoadChangedDelegate, float, NewValue);
 
 class AModularRobot;
 class UModularRobotStatusAsset;
@@ -23,8 +25,12 @@ class CR4S_API UModularRobotStatusComponent : public UBaseStatusComponent
 public:
 	UModularRobotStatusComponent();
 
-#pragma region Check
-	bool CheckWeightCapacity(const float AdditionalWeight) const;
+#pragma region CheckWeight
+	void CheckTotalWeightCapacity();
+	void CheckArmCapacity();
+
+	FORCEINLINE bool IsOverWeighted() const { return bExceedsTotalWeightLimit; }
+	FORCEINLINE bool IsArmOverWeighted() const { return bExceedsArmWeightLimit; }
 #pragma endregion
 	
 #pragma region Refresh
@@ -66,6 +72,8 @@ public:
 
 	void AddMaxWeight(const float InAmount);
 	void AddWeight(const float InAmount);
+	void AddMaxArmMountWeight(const float InAmount);
+	void AddCurrentArmMountWeight(const float InAmount);
 #pragma endregion
 
 #pragma region Modifier
@@ -132,11 +140,14 @@ protected:
 protected:
 	UPROPERTY(VisibleAnywhere,BlueprintReadOnly,Category="Owner")
 	TObjectPtr<AModularRobot> OwningCharacter;
-	UPROPERTY(VisibleAnywhere,BlueprintReadOnly)
+	UPROPERTY(VisibleAnywhere,BlueprintReadOnly, Category="State")
 	uint8 bIsStunned:1 {false};
-	UPROPERTY(VisibleAnywhere,BlueprintReadOnly)
+	UPROPERTY(VisibleAnywhere,BlueprintReadOnly, Category="State")
 	uint8 bIsRobotActive:1 {true};
-	
+	UPROPERTY(VisibleAnywhere,BlueprintReadOnly, Category="State")
+	uint8 bExceedsTotalWeightLimit:1 {false};
+	UPROPERTY(VisibleAnywhere,BlueprintReadOnly, Category="State")
+	uint8 bExceedsArmWeightLimit:1 {false};
 #pragma endregion
 	
 #pragma region Status
@@ -158,6 +169,10 @@ public:
 	FOnWeightChangedDelegate OnWeightChanged;
 	UPROPERTY(VisibleAnywhere,BlueprintReadOnly,Category="Delegate")
 	FOnMaxWeightChangedDelegate OnMaxWeightChanged;
+	UPROPERTY(VisibleAnywhere,BlueprintReadOnly,Category="Delegate")
+	FOnArmLoadChangedDelegate OnArmLoadChanged;
+	UPROPERTY(VisibleAnywhere,BlueprintReadOnly,Category="Delegate")
+	FOnMaxArmLoadChangedDelegate OnMaxArmLoadChanged;
 #pragma endregion
 
 #pragma region Timer

--- a/Source/CR4S/Character/Components/RobotWeaponComponent.cpp
+++ b/Source/CR4S/Character/Components/RobotWeaponComponent.cpp
@@ -181,7 +181,7 @@ void URobotWeaponComponent::BindWidgetWeapon()
 			InGameWidget->BindAmmoWidgetToWeapon(Weapons[i],i);
 			if (AHomingWeapon* Homing=Cast<AHomingWeapon>(Weapons[i]))
 			{
-				InGameWidget->BindLockOnWidgetToHomingWeapon(Homing);
+				InGameWidget->BindLockOnWidgetToHomingWeapon(Homing,i);
 			}
 		}
 	}

--- a/Source/CR4S/Character/Components/RobotWeaponComponent.cpp
+++ b/Source/CR4S/Character/Components/RobotWeaponComponent.cpp
@@ -7,6 +7,7 @@
 #include "RobotInputBufferComponent.h"
 #include "Character/Characters/ModularRobot.h"
 #include "Character/Weapon/RobotWeapon/BaseWeapon.h"
+#include "Character/Weapon/RobotWeapon/HomingWeapon.h"
 #include "Character/Weapon/RobotWeapon/RangedWeapon.h"
 #include "UI/InGame/SurvivalHUD.h"
 #include "Utility/DataLoaderSubsystem.h"
@@ -25,93 +26,71 @@ URobotWeaponComponent::URobotWeaponComponent()
 
 void URobotWeaponComponent::Input_OnAttackLeftArm()
 {
-	if (!OwningCharacter||!OwningCharacter->IsRobotActive()) return;
-	if (!Weapons.IsValidIndex(0)||!IsValid(Weapons[0])) return;
-	
-	if (InputBuffer->CheckInputQueue(EInputType::RobotAttack1))
-	{
-		Weapons[0]->OnAttack();
-	}
+	TryAttackBySlot(0,EInputType::RobotAttack1);
 }
 
 void URobotWeaponComponent::Input_StopAttackLeftArm()
 {
-	if (!OwningCharacter||!OwningCharacter->IsRobotActive()) return;
-	if (!Weapons.IsValidIndex(0)||!IsValid(Weapons[0])) return;
-
-	//InputBuffer->ClearInputQueue();
-	Weapons[0]->StopAttack();
+	StopAttackBySlot(0);
 }
 
 void URobotWeaponComponent::Input_OnAttackRightArm()
 {
-	if (!OwningCharacter||!OwningCharacter->IsRobotActive()) return;
-	
-	if (!Weapons.IsValidIndex(1)||!IsValid(Weapons[1])) return;
-	
-	if (InputBuffer->CheckInputQueue(EInputType::RobotAttack2))
-	{
-		Weapons[1]->OnAttack();
-	}
+	TryAttackBySlot(1,EInputType::RobotAttack2);
 }
 
 void URobotWeaponComponent::Input_StopAttackRightArm()
 {
-	if (!OwningCharacter||!OwningCharacter->IsRobotActive()) return;
-	if (!Weapons.IsValidIndex(1)||!IsValid(Weapons[1])) return;
-
-	//InputBuffer->ClearInputQueue();
-	Weapons[1]->StopAttack();
+	StopAttackBySlot(1);
 }
 
 void URobotWeaponComponent::Input_OnAttackLeftShoulder()
 {
-	if (!OwningCharacter||!OwningCharacter->IsRobotActive()) return;
-	
-	if (!Weapons.IsValidIndex(2)||!IsValid(Weapons[2])) return;
-	
-	if (InputBuffer->CheckInputQueue(EInputType::RobotAttack3))
-	{
-		Weapons[2]->OnAttack();
-	}
+	TryAttackBySlot(2,EInputType::RobotAttack3);
 }
 
 void URobotWeaponComponent::Input_StopAttackLeftShoulder()
 {
-	if (!OwningCharacter||!OwningCharacter->IsRobotActive()) return;
-	if (!Weapons.IsValidIndex(2)||!IsValid(Weapons[2])) return;
-
-	//InputBuffer->ClearInputQueue();
-	Weapons[2]->StopAttack();
+	StopAttackBySlot(2);
 }
 
 void URobotWeaponComponent::Input_OnAttackRightShoulder()
 {
-	if (!OwningCharacter||!OwningCharacter->IsRobotActive()) return;
-	
-	if (!Weapons.IsValidIndex(3)||!IsValid(Weapons[3])) return;
-	
-	if (InputBuffer->CheckInputQueue(EInputType::RobotAttack4))
-	{
-		Weapons[3]->OnAttack();
-	}
+	TryAttackBySlot(3,EInputType::RobotAttack4);
 }
 
 void URobotWeaponComponent::Input_StopAttackRightShoulder()
 {
+	StopAttackBySlot(3);
+}
+
+void URobotWeaponComponent::TryAttackBySlot(const int32 SlotIdx, const EInputType AttackInput)
+{
 	if (!OwningCharacter||!OwningCharacter->IsRobotActive()) return;
-	if (!Weapons.IsValidIndex(3)||!IsValid(Weapons[3])) return;
+	
+	if (!Weapons.IsValidIndex(SlotIdx)||!IsValid(Weapons[SlotIdx])) return;
+	
+	if (InputBuffer->CheckInputQueue(AttackInput))
+	{
+		Weapons[SlotIdx]->OnAttack();
+	}
+}
+
+void URobotWeaponComponent::StopAttackBySlot(const int32 SlotIdx)
+{
+	if (!OwningCharacter||!OwningCharacter->IsRobotActive()) return;
+	if (!Weapons.IsValidIndex(SlotIdx)||!IsValid(Weapons[SlotIdx])) return;
 
 	//InputBuffer->ClearInputQueue();
-	Weapons[3]->StopAttack();
+	Weapons[SlotIdx]->StopAttack();
 }
 
 void URobotWeaponComponent::EquipWeaponByTag(const FGameplayTag& Tag, const int32 SlotIdx)
 {
-	if (!CR4S_ENSURE(LogHong1,Weapons.IsValidIndex(SlotIdx))) return;
+	if (!CR4S_ENSURE(LogHong1,Weapons.IsValidIndex(SlotIdx) && OwningCharacter)) return;
 
 	// Can't equip MeleeWeapon on Shouler (Only Arm)
-	if (Tag.MatchesTag(WeaponTags::Melee)&&SlotIdx>1) return;
+	if (Tag.MatchesTag(WeaponTags::Melee) && !IsArmSlot(SlotIdx)) return;
 	
 	UGameInstance* GI=OwningCharacter->GetGameInstance();
 	if (!CR4S_ENSURE(LogHong1,GI)) return;

--- a/Source/CR4S/Character/Components/RobotWeaponComponent.cpp
+++ b/Source/CR4S/Character/Components/RobotWeaponComponent.cpp
@@ -85,6 +85,20 @@ void URobotWeaponComponent::StopAttackBySlot(const int32 SlotIdx)
 	Weapons[SlotIdx]->StopAttack();
 }
 
+void URobotWeaponComponent::RefreshWeaponUI()
+{
+	for (ABaseWeapon* Weapon:Weapons)
+	{
+		if (IsValid(Weapon))
+		{
+			if (ARangedWeapon* RangedWeapon=Cast<ARangedWeapon>(Weapon))
+			{
+				RangedWeapon->RefreshUI();
+			}
+		}
+	}
+}
+
 void URobotWeaponComponent::EquipWeaponByTag(const FGameplayTag& Tag, const int32 SlotIdx)
 {
 	if (!CR4S_ENSURE(LogHong1,Weapons.IsValidIndex(SlotIdx) && OwningCharacter)) return;

--- a/Source/CR4S/Character/Components/RobotWeaponComponent.h
+++ b/Source/CR4S/Character/Components/RobotWeaponComponent.h
@@ -48,6 +48,7 @@ public:
 	
 #pragma region EquipWeapon
 public:
+	void RefreshWeaponUI();
 	UFUNCTION(BlueprintCallable)
 	void EquipWeaponByTag(const FGameplayTag& Tag, const int32 SlotIdx);
 	void UnequipWeapon(const int32 SlotIdx);
@@ -71,7 +72,8 @@ protected:
 	
 	//Left, Right Arm (0,1), Left, Right Shoulder(2,3)	UPROPERTY(VisibleAnywhere, BlueprintReadOnly)
 	UPROPERTY(EditAnywhere, Instanced, BlueprintReadWrite, Category="Weapons")
-	TArray<TObjectPtr<ABaseWeapon>> Weapons; 
+	TArray<TObjectPtr<ABaseWeapon>> Weapons;
+
 #pragma endregion
 
 #pragma region WeaponSettings

--- a/Source/CR4S/Character/Components/RobotWeaponComponent.h
+++ b/Source/CR4S/Character/Components/RobotWeaponComponent.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "InputBufferComponent.h"
 #include "Character/Data/RobotSettings.h"
 #include "RobotWeaponComponent.generated.h"
 
@@ -40,12 +41,18 @@ public:
 	void Input_OnAttackRightShoulder();
 	UFUNCTION(BlueprintCallable)
 	void Input_StopAttackRightShoulder();
+
+	void TryAttackBySlot(const int32 SlotIdx, const EInputType AttackInput);
+	void StopAttackBySlot(const int32 SlotIdx);
 #pragma endregion
 	
 #pragma region EquipWeapon
+public:
 	UFUNCTION(BlueprintCallable)
 	void EquipWeaponByTag(const FGameplayTag& Tag, const int32 SlotIdx);
-	void BindWidgetWeapon(ABaseWeapon* Target, const int32 SlotIdx);
+	void UnequipWeapon(const int32 SlotIdx);
+	void BindWidgetWeapon();
+	bool IsArmSlot(const int32 SlotIdx) const;
 #pragma endregion
 
 #pragma region Overrides

--- a/Source/CR4S/Character/Data/ModularRobotStatus.h
+++ b/Source/CR4S/Character/Data/ModularRobotStatus.h
@@ -53,7 +53,9 @@ public:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	float Weight{0};
 	UPROPERTY(EditAnywhere, BlueprintReadWrite)
-	float MaxArmLoad{0};
+	float MaxArmMountWeight{0};
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	float CurrentArmMountWeight{0};
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	float RecoilModifier{1};

--- a/Source/CR4S/Character/Data/RobotSettings.h
+++ b/Source/CR4S/Character/Data/RobotSettings.h
@@ -16,7 +16,9 @@ struct CR4S_API FRobotSettings
 	GENERATED_BODY()
 public:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Input")
-	int32 MappingContextPriority{2};
+	int32 MovementMappingContextPriority{2};
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Input")
+	int32 UtilityMappingContextPriority{2};
 	
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Mount")
 	float UnMountOffset {-200};

--- a/Source/CR4S/Character/UI/AmmoWidget.cpp
+++ b/Source/CR4S/Character/UI/AmmoWidget.cpp
@@ -19,6 +19,8 @@ void UAmmoWidget::NativeConstruct()
 	AmmoProgressWidgets.Add(RightArmCurrentAmmo);
 	AmmoProgressWidgets.Add(LeftShoulderCurrentAmmo);
 	AmmoProgressWidgets.Add(RightShoulderCurrentAmmo);
+
+	CachedWeapons.SetNum(4);
 }
 
 
@@ -45,6 +47,25 @@ void UAmmoWidget::InitializeWidgetForWeapon(ABaseWeapon* InWeapon, const int32 S
 			WeakThis->UpdateCurrentAmmoWidget(SlotIdx,InPercent);
 		}
 	});
+
+	if (!CR4S_ENSURE(LogHong1,CachedWeapons.IsValidIndex(SlotIdx))) return;
+	
+	CachedWeapons[SlotIdx]=InWeapon;
+}
+
+void UAmmoWidget::ClearBindingsToWeapon()
+{
+	for (int32 i=0;i<CachedWeapons.Num();i++)
+	{
+		if (CachedWeapons.IsValidIndex(i))
+		{
+			if (ARangedWeapon* RangedWeapon=Cast<ARangedWeapon>(CachedWeapons[i]))
+			{
+				RangedWeapon->OnCurrentAmmoChanged.RemoveAll(this);
+				
+			}
+		}
+	}
 }
 
 void UAmmoWidget::UpdateCurrentAmmoWidget(const int32 SlotIdx, const float Percent)

--- a/Source/CR4S/Character/UI/AmmoWidget.h
+++ b/Source/CR4S/Character/UI/AmmoWidget.h
@@ -20,8 +20,9 @@ public:
 
 	virtual void NativeConstruct() override;
 	
-#pragma region InitializeWidget
+#pragma region Bind & Unbind
 	void InitializeWidgetForWeapon(ABaseWeapon* InWeapon, const int32 SlotIdx);
+	void ClearBindingsToWeapon();
 #pragma endregion
 
 #pragma region UpdateWidget
@@ -46,5 +47,10 @@ protected:
 protected:
 	UPROPERTY(EditAnywhere,BlueprintReadWrite, Category = "Setting")
 	float MaxProgress{0.2};
+#pragma endregion
+
+#pragma region Cached
+	UPROPERTY(VisibleAnywhere,BlueprintReadOnly, Category = "Cached")
+	TArray<TObjectPtr<ABaseWeapon>> CachedWeapons;
 #pragma endregion
 };

--- a/Source/CR4S/Character/UI/LockOnWidget.cpp
+++ b/Source/CR4S/Character/UI/LockOnWidget.cpp
@@ -28,6 +28,21 @@ void ULockOnWidget::InitializeWidgetForWeapon(AHomingWeapon* HomingWeapon)
 	HomingWeapon->OnLockOnCanceled.AddDynamic(this,&ULockOnWidget::UpdateImageInvisible);
 	HomingWeapon->OnLockOnFinished.AddDynamic(this,&ULockOnWidget::SetLockedOnColor);
 	HomingWeapon->OnTryingToLockOn.AddDynamic(this,&ULockOnWidget::UpdateImagePosition);
+
+	CachedHomingWeapon=HomingWeapon;
+}
+
+void ULockOnWidget::ClearBinding()
+{
+	if (CachedHomingWeapon.IsValid())
+	{
+		CachedHomingWeapon->OnLockOnStarted.RemoveDynamic(this,&ULockOnWidget::UpdateImageVisible);
+		CachedHomingWeapon->OnLockOnCanceled.RemoveDynamic(this,&ULockOnWidget::UpdateImageInvisible);
+		CachedHomingWeapon->OnLockOnFinished.RemoveDynamic(this,&ULockOnWidget::SetLockedOnColor);
+		CachedHomingWeapon->OnTryingToLockOn.RemoveDynamic(this,&ULockOnWidget::UpdateImagePosition);
+	}
+	UpdateImageInvisible();
+	CachedHomingWeapon=nullptr;
 }
 
 void ULockOnWidget::UpdateImageVisible()

--- a/Source/CR4S/Character/UI/LockOnWidget.h
+++ b/Source/CR4S/Character/UI/LockOnWidget.h
@@ -23,6 +23,7 @@ public:
 
 #pragma region WidgetUpdate & Bind
 	void InitializeWidgetForWeapon(AHomingWeapon* HomingWeapon);
+	void ClearBinding();
 	
 	UFUNCTION(BlueprintCallable)
 	void UpdateImageVisible();
@@ -37,4 +38,7 @@ public:
 protected:
 	UPROPERTY(VisibleAnywhere, BlueprintReadWrite, meta=(BindWidgetOptional))
 	TObjectPtr<UImage> LockOnImage;
+
+	UPROPERTY()
+	TWeakObjectPtr<AHomingWeapon> CachedHomingWeapon;
 };

--- a/Source/CR4S/Character/Weapon/RobotWeapon/BaseWeapon.h
+++ b/Source/CR4S/Character/Weapon/RobotWeapon/BaseWeapon.h
@@ -23,6 +23,7 @@ public:
 	ABaseWeapon();
 
 	FORCEINLINE bool IsSelfStunWeapon() const { return BaseInfo.bHasSelfStun; }
+	FORCEINLINE float GetWeaponWeight() const { return BaseInfo.Weight; }
 	
 	virtual void Initialize(AModularRobot* OwnerCharacter, const int32 SlotIdx);
 #pragma region Attack

--- a/Source/CR4S/Character/Weapon/RobotWeapon/HomingWeapon.cpp
+++ b/Source/CR4S/Character/Weapon/RobotWeapon/HomingWeapon.cpp
@@ -34,7 +34,7 @@ void AHomingWeapon::OnAttack()
 
 	if (TargetActor && TargetActor!=GetOwner())
 	{
-		bIsAttackButtonHeldDonw=true;
+		bIsAttackButtonHeldDown=true;
 		
 		bIsTryingToLockOn = true;
 		bIsLockedOn = false;
@@ -54,9 +54,9 @@ void AHomingWeapon::Initialize(AModularRobot* OwnerCharacter, const int32 SlotId
 void AHomingWeapon::StopAttack()
 {
 	CR4S_SIMPLE_SCOPE_LOG;
-	if (!bIsAttackButtonHeldDonw) return;
+	if (!bIsAttackButtonHeldDown) return;
 
-	bIsAttackButtonHeldDonw=false;
+	bIsAttackButtonHeldDown=false;
 	
 	bIsTryingToLockOn = false;
 	SetActorTickEnabled(false);

--- a/Source/CR4S/Character/Weapon/RobotWeapon/HomingWeapon.cpp
+++ b/Source/CR4S/Character/Weapon/RobotWeapon/HomingWeapon.cpp
@@ -46,18 +46,6 @@ void AHomingWeapon::OnAttack()
 void AHomingWeapon::Initialize(AModularRobot* OwnerCharacter, const int32 SlotIdx)
 {
 	Super::Initialize(OwnerCharacter, SlotIdx);
-	if (!CR4S_ENSURE(LogHong1,OwningCharacter)) return;
-	
-	APlayerController* PC=Cast<APlayerController>(OwningCharacter->GetController());
-	if (!CR4S_ENSURE(LogHong1,PC)) return;
-
-	ASurvivalHUD* CurrentHUD=Cast<ASurvivalHUD>(PC->GetHUD());
-	if (!CR4S_ENSURE(LogHong1,CurrentHUD)) return;
-
-	UDefaultInGameWidget* InGaemWidget=CurrentHUD->GetInGameWidget();
-	if (!CR4S_ENSURE(LogHong1,InGaemWidget)) return;
-
-	InGaemWidget->BindLockOnWidgetToHomingWeapon(this);
 }
 
 void AHomingWeapon::StopAttack()

--- a/Source/CR4S/Character/Weapon/RobotWeapon/HomingWeapon.cpp
+++ b/Source/CR4S/Character/Weapon/RobotWeapon/HomingWeapon.cpp
@@ -18,6 +18,7 @@ AHomingWeapon::AHomingWeapon()
 
 void AHomingWeapon::OnAttack()
 {
+	CR4S_SIMPLE_SCOPE_LOG;
 	if (!bCanAttack||bIsReloading||bIsTryingToLockOn) return;
 	
 	if (TypeSpecificInfo.AmmoInfo.CurrentAmmo<=0)
@@ -33,6 +34,8 @@ void AHomingWeapon::OnAttack()
 
 	if (TargetActor && TargetActor!=GetOwner())
 	{
+		bIsAttackButtonHeldDonw=true;
+		
 		bIsTryingToLockOn = true;
 		bIsLockedOn = false;
 		LockOnDurationCounter=0.f;
@@ -50,8 +53,11 @@ void AHomingWeapon::Initialize(AModularRobot* OwnerCharacter, const int32 SlotId
 
 void AHomingWeapon::StopAttack()
 {
-	if (!bIsTryingToLockOn) return;
+	CR4S_SIMPLE_SCOPE_LOG;
+	if (!bIsAttackButtonHeldDonw) return;
 
+	bIsAttackButtonHeldDonw=false;
+	
 	bIsTryingToLockOn = false;
 	SetActorTickEnabled(false);
 	OnLockOnCanceled.Broadcast();
@@ -89,50 +95,62 @@ void AHomingWeapon::Tick(float DeltaTime)
 {
 	Super::Tick(DeltaTime);
 
-	if (!bIsTryingToLockOn || !TrackingTarget.IsValid())
+	if (!bIsTryingToLockOn)
 	{
-		StopAttack();
+		SetActorTickEnabled(false);
 		return;
 	}
 
 	APlayerController* PC=Cast<APlayerController>(OwningCharacter->GetController());
-	if (!CR4S_ENSURE(LogHong1,PC))
+
+	bool bShouldCancelLockOn=false;
+	if (!CR4S_ENSURE(LogHong1,PC && TrackingTarget.IsValid()))
 	{
-		StopAttack();
-		return;
+		bShouldCancelLockOn=true;
 	}
-
-	FVector TargetLocation=TrackingTarget->GetActorLocation();
-	FVector2D TargetScreenLocation;
-
-	if (PC->ProjectWorldLocationToScreen(TargetLocation, TargetScreenLocation))
+	else
 	{
-		int32 ViewportX, ViewportY;
-		PC->GetViewportSize(ViewportX, ViewportY);
-		const float ActualPixelRadius=ViewportY*TypeSpecificInfo.HomingInfo.LockOnMaintainRadius;
-		const FVector2D ScreenCenter(ViewportX*0.5f,ViewportY*0.5f);
-
-		const float DistanceFromCenter=FVector2D::Distance(ScreenCenter,TargetScreenLocation);
-		if (DistanceFromCenter<=ActualPixelRadius)
+		FVector TargetLocation=TrackingTarget->GetActorLocation();
+		FVector2D TargetScreenLocation;
+		
+		if (PC->ProjectWorldLocationToScreen(TargetLocation, TargetScreenLocation))
 		{
-			LockOnDurationCounter+=DeltaTime;
-			OnTryingToLockOn.Broadcast(TargetScreenLocation);
-			if (!bIsLockedOn && LockOnDurationCounter>=TypeSpecificInfo.HomingInfo.LockOnTime)
+			int32 ViewportX, ViewportY;
+			PC->GetViewportSize(ViewportX, ViewportY);
+			const float ActualPixelRadius=ViewportY*TypeSpecificInfo.HomingInfo.LockOnMaintainRadius;
+			const FVector2D ScreenCenter(ViewportX*0.5f,ViewportY*0.5f);
+
+			const float DistanceFromCenter=FVector2D::Distance(ScreenCenter,TargetScreenLocation);
+			if (DistanceFromCenter<=ActualPixelRadius)
 			{
-				bIsLockedOn=true;
-				OnLockOnFinished.Broadcast();
+				LockOnDurationCounter+=DeltaTime;
+				OnTryingToLockOn.Broadcast(TargetScreenLocation);
+				if (!bIsLockedOn && LockOnDurationCounter>=TypeSpecificInfo.HomingInfo.LockOnTime)
+				{
+					bIsLockedOn=true;
+					OnLockOnFinished.Broadcast();
+				}
+			}
+			else
+			{
+				bIsLockedOn=false;
+				bShouldCancelLockOn=true;	
 			}
 		}
 		else
 		{
 			bIsLockedOn=false;
-			StopAttack();
+			bShouldCancelLockOn=true;
 		}
 	}
-	else
+
+	if (bShouldCancelLockOn)
 	{
+		OnLockOnCanceled.Broadcast();
+		bIsTryingToLockOn=false;
 		bIsLockedOn=false;
-		StopAttack();
+		TrackingTarget=nullptr;
+		SetActorTickEnabled(false);
 	}
 }
 

--- a/Source/CR4S/Character/Weapon/RobotWeapon/HomingWeapon.cpp
+++ b/Source/CR4S/Character/Weapon/RobotWeapon/HomingWeapon.cpp
@@ -18,7 +18,6 @@ AHomingWeapon::AHomingWeapon()
 
 void AHomingWeapon::OnAttack()
 {
-	CR4S_SIMPLE_SCOPE_LOG;
 	if (!bCanAttack||bIsReloading||bIsTryingToLockOn) return;
 	
 	if (TypeSpecificInfo.AmmoInfo.CurrentAmmo<=0)
@@ -53,7 +52,6 @@ void AHomingWeapon::Initialize(AModularRobot* OwnerCharacter, const int32 SlotId
 
 void AHomingWeapon::StopAttack()
 {
-	CR4S_SIMPLE_SCOPE_LOG;
 	if (!bIsAttackButtonHeldDown) return;
 
 	bIsAttackButtonHeldDown=false;

--- a/Source/CR4S/Character/Weapon/RobotWeapon/HomingWeapon.h
+++ b/Source/CR4S/Character/Weapon/RobotWeapon/HomingWeapon.h
@@ -46,6 +46,9 @@ protected:
 
 	UPROPERTY(VisibleAnywhere, Category="LockOn")
 	uint8 bIsTryingToLockOn :1 {false};
+
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category="LockOn")
+	uint8 bIsAttackButtonHeldDonw:1 {false};
 #pragma endregion
 
 #pragma region Delegate

--- a/Source/CR4S/Character/Weapon/RobotWeapon/HomingWeapon.h
+++ b/Source/CR4S/Character/Weapon/RobotWeapon/HomingWeapon.h
@@ -48,7 +48,7 @@ protected:
 	uint8 bIsTryingToLockOn :1 {false};
 
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category="LockOn")
-	uint8 bIsAttackButtonHeldDonw:1 {false};
+	uint8 bIsAttackButtonHeldDown:1 {false};
 #pragma endregion
 
 #pragma region Delegate

--- a/Source/CR4S/Character/Weapon/RobotWeapon/RangedWeapon.cpp
+++ b/Source/CR4S/Character/Weapon/RobotWeapon/RangedWeapon.cpp
@@ -28,6 +28,11 @@ void ARangedWeapon::Initialize(AModularRobot* OwnerCharacter, const int32 SlotId
 	Super::Initialize(OwnerCharacter, SlotIdx);
 }
 
+void ARangedWeapon::RefreshUI()
+{
+	AddCurrentAmmo(0);
+}
+
 void ARangedWeapon::FireMultiBullet(AActor* HomingTarget)
 {
 	const TArray<FName> Muzzles=TypeSpecificInfo.MultiShotInfo.MuzzleSocketNames;

--- a/Source/CR4S/Character/Weapon/RobotWeapon/RangedWeapon.h
+++ b/Source/CR4S/Character/Weapon/RobotWeapon/RangedWeapon.h
@@ -21,6 +21,8 @@ class CR4S_API ARangedWeapon : public ABaseWeapon
 public:
 	// Sets default values for this actor's properties
 	ARangedWeapon();
+
+	void RefreshUI();
 	
 #pragma region Override
 public:

--- a/Source/CR4S/UI/InGame/DefaultInGameWidget.cpp
+++ b/Source/CR4S/UI/InGame/DefaultInGameWidget.cpp
@@ -63,6 +63,7 @@ void UDefaultInGameWidget::BindAmmoWidgetToWeapon(ABaseWeapon* InWeapon, const i
 	CurrentAmmoWidgets->InitializeWidgetForWeapon(InWeapon,SlotIdx);
 }
 
+
 void UDefaultInGameWidget::BindWidgetsToStatus(UBaseStatusComponent* InStatus)
 {
 	if (!CR4S_ENSURE(LogHong1,InStatus && StatusWidget)) return;
@@ -100,6 +101,12 @@ void UDefaultInGameWidget::ClearBindingsToEnvStatus()
 {
 	if (!CR4S_ENSURE(LogHong1,EnvironmentStatusWidget)) return;
 	EnvironmentStatusWidget->ClearBindingsToEnvStatusComp();
+}
+
+void UDefaultInGameWidget::ClearAmmoWidgetToWeapon()
+{
+	if (!CR4S_ENSURE(LogHong1,CurrentAmmoWidgets)) return;
+	CurrentAmmoWidgets->ClearBindingsToWeapon();
 }
 
 void UDefaultInGameWidget::UpdateHungerWidget(const float InPercentage)

--- a/Source/CR4S/UI/InGame/DefaultInGameWidget.cpp
+++ b/Source/CR4S/UI/InGame/DefaultInGameWidget.cpp
@@ -16,11 +16,17 @@
 void UDefaultInGameWidget::NativeConstruct()
 {
 	Super::NativeConstruct();
-	if (!CR4S_ENSURE(LogHong1,LockOnWidget)) return;
 	
 	AimCircle->SetVisibility(ESlateVisibility::Hidden);
-
 	CurrentAmmoWidgets->SetVisibility(ESlateVisibility::Hidden);
+
+	if (LockOnWidgets.IsEmpty())
+	{
+		LockOnWidgets.Add(LockOnWidget0);
+		LockOnWidgets.Add(LockOnWidget1);
+		LockOnWidgets.Add(LockOnWidget2);
+		LockOnWidgets.Add(LockOnWidget3);
+	}
 }
 
 void UDefaultInGameWidget::ToggleWidgetMode(const bool bIsRobot)
@@ -49,11 +55,22 @@ void UDefaultInGameWidget::ToggleWidgetMode(const bool bIsRobot)
 	}
 }
 
-void UDefaultInGameWidget::BindLockOnWidgetToHomingWeapon(AHomingWeapon* HomingWeapon)
+void UDefaultInGameWidget::BindLockOnWidgetToHomingWeapon(AHomingWeapon* HomingWeapon, const int32 SlotIdx)
 {
-	if (!CR4S_ENSURE(LogHong1,HomingWeapon && LockOnWidget)) return;
+	if (!CR4S_ENSURE(LogHong1,LockOnWidgets.IsValidIndex(SlotIdx)&&IsValid(HomingWeapon)&&IsValid(LockOnWidgets[SlotIdx]))) return;
 
-	LockOnWidget->InitializeWidgetForWeapon(HomingWeapon);	
+	LockOnWidgets[SlotIdx]->InitializeWidgetForWeapon(HomingWeapon);
+}
+
+void UDefaultInGameWidget::UnbindAllHomingWeaponFromUI()
+{
+	for (ULockOnWidget* LockOnWidget : LockOnWidgets)
+	{
+		if (IsValid(LockOnWidget))
+		{
+			LockOnWidget->ClearBinding();
+		}
+	}
 }
 
 void UDefaultInGameWidget::BindAmmoWidgetToWeapon(ABaseWeapon* InWeapon, const int32 SlotIdx)
@@ -88,7 +105,7 @@ void UDefaultInGameWidget::BindEnvStatusWidgetToEnvStatus(UEnvironmentalStatusCo
 	EnvironmentStatusWidget->InitializeWidget(InStatus);
 }
 
-void UDefaultInGameWidget::ClearBindingsToStatus()
+void UDefaultInGameWidget::UnbindStatusFromUI()
 {
 	if (!CR4S_ENSURE(LogHong1,StatusWidget)) return;
 	StatusWidget->ClearBindings();
@@ -97,13 +114,13 @@ void UDefaultInGameWidget::ClearBindingsToStatus()
 	EnvironmentStatusWidget->ClearBindingsToStatusComp();
 }
 
-void UDefaultInGameWidget::ClearBindingsToEnvStatus()
+void UDefaultInGameWidget::UnbindEnvStatusFromUI()
 {
 	if (!CR4S_ENSURE(LogHong1,EnvironmentStatusWidget)) return;
 	EnvironmentStatusWidget->ClearBindingsToEnvStatusComp();
 }
 
-void UDefaultInGameWidget::ClearAmmoWidgetToWeapon()
+void UDefaultInGameWidget::UnbindWeaponFromUI()
 {
 	if (!CR4S_ENSURE(LogHong1,CurrentAmmoWidgets)) return;
 	CurrentAmmoWidgets->ClearBindingsToWeapon();

--- a/Source/CR4S/UI/InGame/DefaultInGameWidget.h
+++ b/Source/CR4S/UI/InGame/DefaultInGameWidget.h
@@ -44,6 +44,7 @@ public:
 
 	void ClearBindingsToStatus();
 	void ClearBindingsToEnvStatus();
+	void ClearAmmoWidgetToWeapon();
 #pragma endregion
 	
 #pragma region UpdateWidget

--- a/Source/CR4S/UI/InGame/DefaultInGameWidget.h
+++ b/Source/CR4S/UI/InGame/DefaultInGameWidget.h
@@ -33,18 +33,21 @@ public:
 #pragma region Bind & Unbind
 public:
 	void ToggleWidgetMode(const bool bIsRobot);
+	
 	UFUNCTION(BlueprintCallable)
-	void BindLockOnWidgetToHomingWeapon(AHomingWeapon* HomingWeapon);
+	void BindLockOnWidgetToHomingWeapon(AHomingWeapon* HomingWeapon, const int32 SlotIdx);
+	void UnbindAllHomingWeaponFromUI();
+	
 	UFUNCTION(BlueprintCallable)
 	void BindAmmoWidgetToWeapon(ABaseWeapon* InWeapon, const int32 SlotIdx);
+	void UnbindWeaponFromUI();
 
 	void BindWidgetsToStatus(UBaseStatusComponent* InStatus);
+	void UnbindStatusFromUI();
 	
 	void BindEnvStatusWidgetToEnvStatus(UEnvironmentalStatusComponent* InStatus);
+	void UnbindEnvStatusFromUI();
 
-	void ClearBindingsToStatus();
-	void ClearBindingsToEnvStatus();
-	void ClearAmmoWidgetToWeapon();
 #pragma endregion
 	
 #pragma region UpdateWidget
@@ -78,8 +81,17 @@ protected:
 	UPROPERTY(VisibleAnywhere, BlueprintReadWrite, meta=(BindWidgetOptional))
 	TObjectPtr<UImage> AimCircle;
 	UPROPERTY(VisibleAnywhere, BlueprintReadWrite, meta=(BindWidgetOptional))
-	TObjectPtr<ULockOnWidget> LockOnWidget;
-	UPROPERTY(VisibleAnywhere, BlueprintReadWrite, meta=(BindWidgetOptional))
 	TObjectPtr<UAmmoWidget> CurrentAmmoWidgets;
+
+	UPROPERTY(VisibleAnywhere, BlueprintReadWrite)
+	TArray<TObjectPtr<ULockOnWidget>> LockOnWidgets;
+	UPROPERTY(VisibleAnywhere, BlueprintReadWrite, meta=(BindWidgetOptional))
+	TObjectPtr<ULockOnWidget> LockOnWidget0;
+	UPROPERTY(VisibleAnywhere, BlueprintReadWrite, meta=(BindWidgetOptional))
+	TObjectPtr<ULockOnWidget> LockOnWidget1;
+	UPROPERTY(VisibleAnywhere, BlueprintReadWrite, meta=(BindWidgetOptional))
+	TObjectPtr<ULockOnWidget> LockOnWidget2;
+	UPROPERTY(VisibleAnywhere, BlueprintReadWrite, meta=(BindWidgetOptional))
+	TObjectPtr<ULockOnWidget> LockOnWidget3;
 #pragma endregion
 };


### PR DESCRIPTION
# 유도 무기 상태 관리 로직 안정화
- 기존 로직에서는 Tick()에서 인풋 액션에 바인딩된 함수를 호출하면서 함수 호출 순서가 꼬여 무기의 상태를 나타내는 값이 오염되어 공격 자체를 아예 할 수 없는 상태로 고정되어 버림
- 물리적 입력 상태를 나타내는 상태 값 추가 (bIsAttackButtonHeldDown)
- bIsAttackButtonHeldDown은 오로지 OnAttack, StopAttack 함수에서만 관리 (입력 바인딩 함수들)
- Tick 로직 리팩터링 : StopAttack을 호출하던 코드들 모두 삭제, SetActorTickEnabled를 호출하여 Tick On/Off 및 여타 flag 값 변경만 수행
# IMC 기능 단위 분리
- 로봇 IMC를 움직임 (공격, 이동), 그외 기타(상호작용)으로 분리
- SetInputEnable : 모든 IMC 추가/제거 (스턴 디버프 적용에 사용)
- SetMovementInputEnable : 움직임 관련 IMC만 추가/제거, 로봇 전체 과적 및 팔쪽 과적 상태에 사용하여 하차 입력은 가능하도록
- 현재 파츠 장착 과정에서 무게가 전체/팔 쪽 한계치를 한쪽이라도 넘어가면 움직임 관련 인풋은 모두 무시, 오로지 하차만 가능
# 락온 UI 구조 변경
- 기존 락온 UI 구조로는 유도 무기를 단 1개만 착용 가능
- 총 4개의 무기까지 지원할 수 있도록 DefaultInGameWidget에서 LockOnWidget을 총 4개 관리하도록 변경 
- 바인딩 함수 호출시 슬롯 번호를 함께 받아 동일한 인덱스의 LockOnWidget에 바인딩
- LockOnWidget에도 바인딩 제거 함수 추가하여 바인딩시 캐싱해 두었던 무기 인스턴스를 이용하여 자체적으로 바인딩 해제
# 무기 장착시 무게 관련 변동사항 적용
- BaseWeapon 클래스에 무게 Getter 추가
- 무기 장착시 위 Getter를 이용하여 StatusComponent에 무게 적용 (전체 ,팔)
# 과적 상태의 로봇 조종 불가 상태 구현
- 전체, 팔의 무게 상태가 업데이트 되면 호출할 상태 체크용 함수 구현 : CheckTotalWeightCapacity(), CheckArmCapacity()
- 로봇으로 빙의하는 시점에서 과적 관련 상태를 체크하여 SetMovementInputEnable을 호출하여 IMC를 추가/제거 하여 과적 상태 구현
# 탄약 및 락온 UI 바인딩 시점 변경
- 기존에는 무기 장착 시점에서 UI 바인딩했으나, 게임 기획상 탑승하는 시점에서 바인딩하는 것이 가장 적절 (탑승한 상태에서 무기를 교체할 상황이 없음)
- 바인딩 관련 함수들을 수정하여 로봇에 빙의하는 시점에서 일괄 바인딩할 수 있도록 변경
- 바인딩 해제용 함수 구현
# 기타
- 파츠 장착시 이미 장착된 파츠가 있다면 장착 해제하도록 로직 변경