### PR TITLE
[Fix] Fix Damage Calculation Logic (Character,Robot) & Chage Energy Depleted Debuff 

### DIFF
--- a/Source/CR4S/Character/Characters/ModularRobot.cpp
+++ b/Source/CR4S/Character/Characters/ModularRobot.cpp
@@ -871,7 +871,7 @@ void AModularRobot::Tick(float DeltaTime)
 
 void AModularRobot::Input_Move(const FInputActionValue& Value)
 {
-	if (!Controller||!Status->IsRobotActive()) return;
+	if (!Controller) return;
 	//Move Logic
 	// input is a Vector2D
 	FVector2D MoveInput = Value.Get<FVector2D>();
@@ -888,7 +888,6 @@ void AModularRobot::Input_Move(const FInputActionValue& Value)
 
 void AModularRobot::Input_Look(const FInputActionValue& Value)
 {
-	if (!CR4S_ENSURE(LogHong1,Status->IsRobotActive())) return;
 	FVector2D LookInput=Value.Get<FVector2D>();
 
 	AddControllerYawInput(LookInput.X);
@@ -897,9 +896,7 @@ void AModularRobot::Input_Look(const FInputActionValue& Value)
 
 void AModularRobot::Input_StartJump(const FInputActionValue& Value)
 {
-	if (!CR4S_ENSURE(LogHong1,Status->IsRobotActive())) return;
-	
-	if (GetCharacterMovement()->IsFalling() && !bIsHovering)
+	if (GetCharacterMovement()->IsFalling() && !bIsHovering && Status->IsRobotActive())
 	{
 		Status->StartHover();
 		bIsHovering=true;
@@ -913,8 +910,6 @@ void AModularRobot::Input_StartJump(const FInputActionValue& Value)
 
 void AModularRobot::Input_StopJump(const FInputActionValue& Value)
 {
-	if (!CR4S_ENSURE(LogHong1,Status->IsRobotActive())) return;
-	
 	StopJumping();
 
 	if (bIsHovering)
@@ -927,7 +922,7 @@ void AModularRobot::Input_StopJump(const FInputActionValue& Value)
 
 void AModularRobot::Input_Dash(const FInputActionValue& Value)
 {
-	if (bIsDashing||!Status->HasEnoughResourceForRoll()||!Status->IsRobotActive()|| !BoosterTag.IsValid()) return;
+	if (bIsDashing||!Status->HasEnoughResourceForRoll()||!BoosterTag.IsValid()||!Status->IsRobotActive()) return;
 	
 	bIsDashing = true;
 	

--- a/Source/CR4S/Character/Characters/PlayerCharacter.cpp
+++ b/Source/CR4S/Character/Characters/PlayerCharacter.cpp
@@ -76,6 +76,7 @@ void APlayerCharacter::GatherSaveData(FSavedActorData& OutSaveData)
 	PlayerData.EquippedToolTag= CurrentTool ? CurrentTool->GetToolGameplayTag() : FGameplayTag::EmptyTag;
 	PlayerData.Stance=GetStance();
 	PlayerData.Gait=GetGait();
+	PlayerData.OverlayMode=GetOverlayMode();
 	PlayerData.bIsRightShoulder=Camera->IsRightShoulder();
 
 	PlayerInventory->LoadPlayerInventorySaveGame(PlayerData.InventorySaveGame,PlayerData.QuickSlotSaveGame);
@@ -95,6 +96,7 @@ void APlayerCharacter::ApplySaveData(FSavedActorData& InSaveData)
 	SetCurrentToolByTag(PlayerData.EquippedToolTag);
 	SetDesiredStance(PlayerData.Stance);
 	SetDesiredGait(PlayerData.Gait);
+	SetOverlayMode(PlayerData.OverlayMode);
 	Camera->SetRightShoulder(PlayerData.bIsRightShoulder);
 
 	PlayerInventory->LoadPlayerInventorySaveGame(PlayerData.InventorySaveGame,PlayerData.QuickSlotSaveGame);

--- a/Source/CR4S/Character/Characters/PlayerCharacter.cpp
+++ b/Source/CR4S/Character/Characters/PlayerCharacter.cpp
@@ -79,7 +79,7 @@ void APlayerCharacter::GatherSaveData(FSavedActorData& OutSaveData)
 	PlayerData.OverlayMode=GetOverlayMode();
 	PlayerData.bIsRightShoulder=Camera->IsRightShoulder();
 
-	PlayerInventory->LoadPlayerInventorySaveGame(PlayerData.InventorySaveGame,PlayerData.QuickSlotSaveGame);
+	PlayerInventory->GetPlayerInventorySaveGame(PlayerData.InventorySaveGame,PlayerData.QuickSlotSaveGame);
 }
 
 void APlayerCharacter::ApplySaveData(FSavedActorData& InSaveData)

--- a/Source/CR4S/Character/Components/BaseStatusComponent.cpp
+++ b/Source/CR4S/Character/Components/BaseStatusComponent.cpp
@@ -19,7 +19,7 @@ UBaseStatusComponent::UBaseStatusComponent()
 void UBaseStatusComponent::TakeDamage(const float DamageAmount)
 {
 	const float ArmorFactor=BaseStatus.Armor;
-	const float ComputedDamage = DamageAmount+(BaseStatus.ArmorConstant/(BaseStatus.ArmorConstant+ArmorFactor));
+	const float ComputedDamage = DamageAmount*(BaseStatus.ArmorConstant/(BaseStatus.ArmorConstant+ArmorFactor));
 
 	AddCurrentHP(-(ComputedDamage));
 }

--- a/Source/CR4S/Character/Components/BaseStatusComponent.cpp
+++ b/Source/CR4S/Character/Components/BaseStatusComponent.cpp
@@ -19,7 +19,7 @@ UBaseStatusComponent::UBaseStatusComponent()
 void UBaseStatusComponent::TakeDamage(const float DamageAmount)
 {
 	const float ArmorFactor=BaseStatus.Armor;
-	const float ComputedDamage = DamageAmount*(BaseStatus.ArmorConstant/(BaseStatus.ArmorConstant*ArmorFactor));
+	const float ComputedDamage = DamageAmount+(BaseStatus.ArmorConstant/(BaseStatus.ArmorConstant+ArmorFactor));
 
 	AddCurrentHP(-(ComputedDamage));
 }

--- a/Source/CR4S/Character/Components/ModularRobotStatusComponent.cpp
+++ b/Source/CR4S/Character/Components/ModularRobotStatusComponent.cpp
@@ -164,7 +164,7 @@ void UModularRobotStatusComponent::ApplyEnergyDepletedDebuff() const
 {
 	if (!CR4S_ENSURE(LogHong1, OwningCharacter && OwningCharacter->GetCharacterMovement()))
 	{
-		OwningCharacter->GetCharacterMovement()->MaxWalkSpeed*RobotStatus.EnergyDepletedSpeedMultiplier;
+		OwningCharacter->GetCharacterMovement()->MaxWalkSpeed*=RobotStatus.EnergyDepletedSpeedMultiplier;
 	}
 }
 
@@ -173,7 +173,7 @@ void UModularRobotStatusComponent::RemoveEnergyDepletedDebuff() const
 	if (!CR4S_ENSURE(LogHong1, OwningCharacter
 	                 && OwningCharacter->GetCharacterMovement()))
 	{
-		OwningCharacter->GetCharacterMovement()->MaxWalkSpeed/RobotStatus.EnergyDepletedSpeedMultiplier;
+		OwningCharacter->GetCharacterMovement()->MaxWalkSpeed/=RobotStatus.EnergyDepletedSpeedMultiplier;
 	}
 }
 

--- a/Source/CR4S/Character/Components/ModularRobotStatusComponent.cpp
+++ b/Source/CR4S/Character/Components/ModularRobotStatusComponent.cpp
@@ -160,6 +160,23 @@ void UModularRobotStatusComponent::SetMaxEnergy(const float NewValue)
 	OnEnergyChanged.Broadcast(Percentage);
 }
 
+void UModularRobotStatusComponent::ApplyEnergyDepletedDebuff() const
+{
+	if (!CR4S_ENSURE(LogHong1, OwningCharacter && OwningCharacter->GetCharacterMovement()))
+	{
+		OwningCharacter->GetCharacterMovement()->MaxWalkSpeed*RobotStatus.EnergyDepletedSpeedMultiplier;
+	}
+}
+
+void UModularRobotStatusComponent::RemoveEnergyDepletedDebuff() const
+{
+	if (!CR4S_ENSURE(LogHong1, OwningCharacter
+	                 && OwningCharacter->GetCharacterMovement()))
+	{
+		OwningCharacter->GetCharacterMovement()->MaxWalkSpeed/RobotStatus.EnergyDepletedSpeedMultiplier;
+	}
+}
+
 void UModularRobotStatusComponent::SetCurrentEnergy(const float NewValue)
 {
 	const float ClampedEnergy = FMath::Clamp(NewValue, 0.f, RobotStatus.MaxEnergy);
@@ -178,6 +195,7 @@ void UModularRobotStatusComponent::SetCurrentEnergy(const float NewValue)
 		{
 			bIsRobotActive = false;
 			StopConsumeEnergy();
+			ApplyEnergyDepletedDebuff();
 		}
 	}
 	else
@@ -185,6 +203,7 @@ void UModularRobotStatusComponent::SetCurrentEnergy(const float NewValue)
 		if (!bIsRobotActive)
 		{
 			bIsRobotActive = true;
+			RemoveEnergyDepletedDebuff();
 		}
 	}
 }

--- a/Source/CR4S/Character/Components/ModularRobotStatusComponent.cpp
+++ b/Source/CR4S/Character/Components/ModularRobotStatusComponent.cpp
@@ -19,7 +19,7 @@ UModularRobotStatusComponent::UModularRobotStatusComponent()
 void UModularRobotStatusComponent::TakeDamage(const float DamageAmount)
 {
 	const float ArmorFactor=BaseStatus.Armor*RobotStatus.ArmorMultiplier;
-	const float ComputedDamage = DamageAmount*(BaseStatus.ArmorConstant+(BaseStatus.ArmorConstant*ArmorFactor));
+	const float ComputedDamage = DamageAmount*(BaseStatus.ArmorConstant/(BaseStatus.ArmorConstant+ArmorFactor));
 	
 	AddCurrentHP(-(ComputedDamage));
 }
@@ -162,7 +162,7 @@ void UModularRobotStatusComponent::SetMaxEnergy(const float NewValue)
 
 void UModularRobotStatusComponent::ApplyEnergyDepletedDebuff() const
 {
-	if (!CR4S_ENSURE(LogHong1, OwningCharacter && OwningCharacter->GetCharacterMovement()))
+	if (CR4S_ENSURE(LogHong1, OwningCharacter && OwningCharacter->GetCharacterMovement()))
 	{
 		OwningCharacter->GetCharacterMovement()->MaxWalkSpeed*=RobotStatus.EnergyDepletedSpeedMultiplier;
 	}
@@ -170,7 +170,7 @@ void UModularRobotStatusComponent::ApplyEnergyDepletedDebuff() const
 
 void UModularRobotStatusComponent::RemoveEnergyDepletedDebuff() const
 {
-	if (!CR4S_ENSURE(LogHong1, OwningCharacter
+	if (CR4S_ENSURE(LogHong1, OwningCharacter
 	                 && OwningCharacter->GetCharacterMovement()))
 	{
 		OwningCharacter->GetCharacterMovement()->MaxWalkSpeed/=RobotStatus.EnergyDepletedSpeedMultiplier;

--- a/Source/CR4S/Character/Components/ModularRobotStatusComponent.cpp
+++ b/Source/CR4S/Character/Components/ModularRobotStatusComponent.cpp
@@ -19,7 +19,7 @@ UModularRobotStatusComponent::UModularRobotStatusComponent()
 void UModularRobotStatusComponent::TakeDamage(const float DamageAmount)
 {
 	const float ArmorFactor=BaseStatus.Armor*RobotStatus.ArmorMultiplier;
-	const float ComputedDamage = DamageAmount*(BaseStatus.ArmorConstant/(BaseStatus.ArmorConstant*ArmorFactor));
+	const float ComputedDamage = DamageAmount*(BaseStatus.ArmorConstant+(BaseStatus.ArmorConstant*ArmorFactor));
 	
 	AddCurrentHP(-(ComputedDamage));
 }

--- a/Source/CR4S/Character/Components/ModularRobotStatusComponent.h
+++ b/Source/CR4S/Character/Components/ModularRobotStatusComponent.h
@@ -66,6 +66,8 @@ public:
 
 #pragma region Set
 	void SetMaxEnergy(const float NewValue);
+	void ApplyEnergyDepletedDebuff() const;
+	void RemoveEnergyDepletedDebuff() const;
 	void SetCurrentEnergy(const float NewValue);
 
 	void SetMaxStun(const float NewValue);

--- a/Source/CR4S/Character/Data/ModularRobotStatus.h
+++ b/Source/CR4S/Character/Data/ModularRobotStatus.h
@@ -22,6 +22,8 @@ public:
 	float EnergyConsumptionInterval{0.1};
 	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	float EnergyEfficiency{1};
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	float EnergyDepletedSpeedMultiplier {0.3};
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	float HoverCostMultiplier{0.1};

--- a/Source/CR4S/Game/SaveGame/PlayerCharacterSaveGame.h
+++ b/Source/CR4S/Game/SaveGame/PlayerCharacterSaveGame.h
@@ -35,6 +35,8 @@ public:
 	UPROPERTY(VisibleAnywhere, Category = "SaveData | ALS")
 	FGameplayTag Gait;
 	UPROPERTY(VisibleAnywhere, Category = "SaveData | ALS")
+	FGameplayTag OverlayMode;
+	UPROPERTY(VisibleAnywhere, Category = "SaveData | ALS")
 	uint8 bIsRightShoulder:1 {true};
 
 	UPROPERTY(VisibleAnywhere, Category = "SaveData | Inventory")


### PR DESCRIPTION
# 데미지 계산 로직 수정
- 캐릭터, 로봇 : 잘못되어 있던 계산식 연산자 올바르게 수정
- BaseStatusComponent, ModularRobotStatusComponent TakeDamage 참조
# 에너지 디버프 효과 변경
- 이동속도 감소 (0.3배)
- 공격, 대쉬, 호버링 기능 사용 불가
- 이동만 가능
# 기타
- 세이브되는 데이터에 오버레이 모드 추가
- OverlayMode : 현재 캐릭터가 들고 있던 도구와 도구에 맞는 애니메이션을 나타내는 태그
- 저장 시점에 들고 있던 도구가 로드하는 시점에서 그대로 적용
- 캐릭터 데이터 저장 함수 (GatherSaveData)에 잘못 사용되던 함수 올바르게 교체 
LoadPlayerInventorySaveGame -> GetPlayerInventorySaveGame