### PR TITLE
[Add] Feature/monster/season/ceres detail

### DIFF
--- a/Content/CR4S/_Blueprint/MonsterAI/Animations/SeasonBoss/FrostSeasonBoss/AM_HiemsDeath.uasset
+++ b/Content/CR4S/_Blueprint/MonsterAI/Animations/SeasonBoss/FrostSeasonBoss/AM_HiemsDeath.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0193125822a2880d111334b2064dc32e5f727541bef11d05fb6703bb99c31d54
-size 9345
+oid sha256:46ddf7608aa3a8df92e2906988d9c96cc11fc5bfb899b8a1663f91e5919cf9a5
+size 9354

--- a/Content/CR4S/_Blueprint/MonsterAI/Animations/SeasonBoss/RainySeasonBoss/AM_MaxDiscomfort.uasset
+++ b/Content/CR4S/_Blueprint/MonsterAI/Animations/SeasonBoss/RainySeasonBoss/AM_MaxDiscomfort.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:55ee3fc32d940a3f94a634fb136b7d460cb0ad037d80009f696390e5fc575779
-size 12931
+oid sha256:a934e1a7641c6d3634a88b211ac62cf6182c1342379a1a7b1389ce1efd1389ad
+size 13027

--- a/Source/CR4S/MonsterAI/BaseMonster.cpp
+++ b/Source/CR4S/MonsterAI/BaseMonster.cpp
@@ -10,6 +10,8 @@
 #include "Data/MonsterAIKeyNames.h" 
 #include "Game/System/AudioManager.h"
 #include "GameFramework/CharacterMovementComponent.h"
+#include "Inventory/Components/BaseInventoryComponent.h"
+#include "Kismet/GameplayStatics.h"
 
 ABaseMonster::ABaseMonster()
 	: MyHeader(TEXT("BaseMonster"))
@@ -123,6 +125,11 @@ void ABaseMonster::HandleDeath()
 	StateComponent->SetState(EMonsterState::Dead);
 	OnDied.Broadcast(this);
 
+	if (UBaseInventoryComponent* InventoryComp = GetPlayerInventory())
+	{
+		TryDropItems(InventoryComp);
+	}
+
 	if (UCharacterMovementComponent* MoveComp = GetCharacterMovement())
 		MoveComp->DisableMovement();
 
@@ -218,4 +225,41 @@ void ABaseMonster::OnMonsterStateChanged(EMonsterState Previous, EMonsterState C
 		*UEnum::GetValueAsString(Previous),
 		*UEnum::GetValueAsString(Current)
 	);
+}
+
+UBaseInventoryComponent* ABaseMonster::GetPlayerInventory() const
+{
+	if (APawn* Pawn = UGameplayStatics::GetPlayerPawn(GetWorld(), 0))
+	{
+		return Pawn->FindComponentByClass<UBaseInventoryComponent>();
+	}
+	return nullptr;
+}
+
+void ABaseMonster::TryDropItems(UBaseInventoryComponent* InventoryComp) const
+{
+	if (DropItems.IsEmpty())
+		return;
+
+	TMap<FName,int32> ItemsToAdd;
+	for (const FDropData& DropData : DropItems)
+	{
+		if (!DropData.DropItemRowName.IsNone() && DropData.DropItemCount > 0)
+		{
+			ItemsToAdd.FindOrAdd(DropData.DropItemRowName) += DropData.DropItemCount;
+		}
+	}
+	if (ItemsToAdd.IsEmpty())
+		return;
+
+	InventoryComp->AddItems(ItemsToAdd);
+
+	// NOTICE :: TestLog
+	for (auto& Pair : ItemsToAdd)
+	{
+		UE_LOG(LogTemp, Log, TEXT("[%s] Dropped %s x%d"),
+			*GetClass()->GetName(),
+			*Pair.Key.ToString(),
+			Pair.Value);
+	}
 }

--- a/Source/CR4S/MonsterAI/BaseMonster.h
+++ b/Source/CR4S/MonsterAI/BaseMonster.h
@@ -7,11 +7,24 @@
 #include "Utility/StunnableInterface.h"
 #include "BaseMonster.generated.h"
 
+class UBaseInventoryComponent;
 class UMonsterAttributeComponent;
 class UMonsterSkillComponent;
 class UMonsterStateComponent;
 class UMonsterAnimComponent;
 class UBehaviorTree;
+
+USTRUCT(BlueprintType)
+struct FDropData
+{
+	GENERATED_BODY()
+	
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Drops")
+	FName DropItemRowName = NAME_None;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Drops", meta=(ClampMin="1"))
+	int32 DropItemCount = 1;
+};
 
 UCLASS()
 class CR4S_API ABaseMonster : public ACharacter, public ISpawnable, public IStunnableInterface
@@ -89,8 +102,14 @@ public:
 protected:
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Monster|State")
  	bool bIsDead = false;
+	
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Monster|ItemDrops")
+	TArray<FDropData> DropItems;
 
 private:
+	UBaseInventoryComponent* GetPlayerInventory() const;
+	void TryDropItems(UBaseInventoryComponent* Inv) const;
+	
 	FTimerHandle FadeTimerHandle;
 	float ElapsedFadeTime = 0.f;
 

--- a/Source/CR4S/MonsterAI/BossMonster/Season/CeresRainyBossMonster.cpp
+++ b/Source/CR4S/MonsterAI/BossMonster/Season/CeresRainyBossMonster.cpp
@@ -4,4 +4,5 @@ ACeresRainyBossMonster::ACeresRainyBossMonster()
 {
 	MonsterID = TEXT("CeresRainyBoss");
 	EnvHumidDelta = 20.f;
+	DropItems.Add({ FName("TearOfSorrow"), 1 });
 }

--- a/Source/CR4S/MonsterAI/BossMonster/Season/HiemsFrostBossMonster.cpp
+++ b/Source/CR4S/MonsterAI/BossMonster/Season/HiemsFrostBossMonster.cpp
@@ -6,4 +6,5 @@ AHiemsFrostBossMonster::AHiemsFrostBossMonster()
 {
 	MonsterID = TEXT("HiemsFrostBoss");
 	EnvTempDelta = -10.f;
+	DropItems.Add({ FName("IceCrystal"), 1 });
 }

--- a/Source/CR4S/MonsterAI/BossMonster/Season/VitaDryBossMonster.cpp
+++ b/Source/CR4S/MonsterAI/BossMonster/Season/VitaDryBossMonster.cpp
@@ -4,4 +4,5 @@ AVitaDryBossMonster::AVitaDryBossMonster()
 {
 	MonsterID = TEXT("VitaDryBoss");
 	EnvTempDelta = 10.f;
+	DropItems.Add({ FName("HeartOfTheSun"), 1 });
 }


### PR DESCRIPTION
## 추가된 내용
1. 몬스터 사망시 아이템 드롭
- 계절, 지역 모두 소매넣기로 아이템 넣을 수 있게 BaseMonster에 아이템 드롭 관련 함수 추가했습니다.
- 보스별로 드롭하는 아이템 종류나 갯수가 다르기에 구조체로 관리하게 만들었습니다.
- 여러 종류 아이템 드롭해야할 때는 DropItems에 Add만 해주시면 됩니다.

## 아이템 드롭 사용 예시
```cpp
AHiemsFrostBossMonster::AHiemsFrostBossMonster()
{
	MonsterID = TEXT("HiemsFrostBoss");
	EnvTempDelta = -10.f;
	DropItems.Add({ FName("IceCrystal"), 1 });

        // 다른 종류의 아이템도 드롭할 때
	// DropItems.Add({ FName("OtherItem"), 1 });
}
```

## 수정된 내용
- 혹한기 보스 사망 모션 순서 바뀐 부분 수정
- 우기 보스 등장 이펙트 크기 조절