### PR TITLE
[Update] Linked GameOVerWidget To Player's Death

### DIFF
--- a/Content/CR4S/_Art/Texture/UI/T_GameOverWindowBG.uasset
+++ b/Content/CR4S/_Art/Texture/UI/T_GameOverWindowBG.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3f595c13cd039f75c54da039b30f59a9935b497221994b77a113bb5bfab27d08
+size 12381

--- a/Content/CR4S/_Blueprint/FrameWork/GameMode/BP_C4SurvivalGameMode.uasset
+++ b/Content/CR4S/_Blueprint/FrameWork/GameMode/BP_C4SurvivalGameMode.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:44d71960ceb40ec6ac7c3fc9e32dd062da867c88cc9ac310aad2815ad2783daa
-size 21768
+oid sha256:f8f02237bc6f151c20f7105a33eb29d768ffbd7855c02d0d954dac593eb1b395
+size 22287

--- a/Content/CR4S/_Blueprint/FrameWork/Manager/BP_EnvironmentManager.uasset
+++ b/Content/CR4S/_Blueprint/FrameWork/Manager/BP_EnvironmentManager.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f8f382aad80e17b71cbfc58520f5a8e5359165e5ec5fd1c58a6cf0a95147641f
-size 226765
+oid sha256:2596693e186ff11674998e51754e101970c4ba273c731727d62d1cc86ce34bac
+size 225751

--- a/Content/CR4S/_Blueprint/UI/InGame/BP_SurvivalHUD.uasset
+++ b/Content/CR4S/_Blueprint/UI/InGame/BP_SurvivalHUD.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1a171baf95d361db536de401e2ffddcd05df075d2a53f7f9611454333f7a9a88
-size 24910
+oid sha256:43e284e2cbef7dbab828b0ea4b3aef8921770beae6ad0123fae014a0767c12a0
+size 25357

--- a/Content/CR4S/_Blueprint/UI/InGame/WBP_GameOverWidget.uasset
+++ b/Content/CR4S/_Blueprint/UI/InGame/WBP_GameOverWidget.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d8415b85c563151f81a34e0c5e4e213a462b9343724a245c2b45b11de53a3744
-size 83516
+oid sha256:e55f1be91e887a4d6deae22e1f2fb22a251954092ba4be49989bb34257085c2f
+size 92217

--- a/Source/CR4S/Game/GameMode/C4SurvivalGameMode.cpp
+++ b/Source/CR4S/Game/GameMode/C4SurvivalGameMode.cpp
@@ -13,6 +13,12 @@ void AC4SurvivalGameMode::StartPlay()
     HandleStartGame();
 }
 
+void AC4SurvivalGameMode::ReturnToMenuWithDelay(float Delay)
+{
+    FTimerHandle TimerHandle;
+    GetWorld()->GetTimerManager().SetTimer(TimerHandle, this, &AC4SurvivalGameMode::ReturnToMenu, Delay, false);
+}
+
 void AC4SurvivalGameMode::ReturnToMenu()
 {
 	UGameplayStatics::OpenLevel(this, FName("MenuLevel"));

--- a/Source/CR4S/Game/GameMode/C4SurvivalGameMode.h
+++ b/Source/CR4S/Game/GameMode/C4SurvivalGameMode.h
@@ -9,9 +9,13 @@ class CR4S_API AC4SurvivalGameMode : public AGameModeBase
 	GENERATED_BODY()
 	
 public:
+	UFUNCTION(BlueprintCallable)
+	void ReturnToMenuWithDelay(float Delay);
+
 	void ReturnToMenu();
 
 protected:
+	
 	UFUNCTION(BlueprintCallable)
 	void EndGameSequence();
 	virtual void StartPlay() override;

--- a/Source/CR4S/UI/InGame/GameOverWidget.cpp
+++ b/Source/CR4S/UI/InGame/GameOverWidget.cpp
@@ -1,5 +1,50 @@
-// Fill out your copyright notice in the Description page of Project Settings.
-
-
 #include "UI/InGame/GameOverWidget.h"
+#include "UI/Common/ButtonWidget.h"
+#include "UI/InGame/SurvivalHUD.h"
+#include "Game/GameMode/C4SurvivalGameMode.h"
+#include "Kismet/GameplayStatics.h"
 
+void UGameOverWidget::NativeConstruct()
+{
+	Super::NativeConstruct();
+
+	if (ToMenuButton)
+	{
+		ToMenuButton->OnClicked().AddDynamic(this, &UGameOverWidget::OnToMenuButtonClicked);
+	}
+
+	if (LoadSaveButton)
+	{
+		LoadSaveButton->OnClicked().AddDynamic(this, &UGameOverWidget::OnToMenuButtonClicked);
+	}
+
+}
+
+void UGameOverWidget::HandleGameOver()
+{
+	PlayAnimation(ShowGameOverAnim);
+}
+
+void UGameOverWidget::OnToMenuButtonClicked()
+{
+	APlayerController* PC = UGameplayStatics::GetPlayerController(this, 0);
+	if (PC)
+	{
+		ASurvivalHUD* HUD = Cast<ASurvivalHUD>(PC->GetHUD());
+		if (HUD)
+		{
+			HUD->ShowLoading();
+		}
+	}
+
+	AC4SurvivalGameMode* GM = Cast<AC4SurvivalGameMode>(UGameplayStatics::GetGameMode(this));
+	if (GM)
+	{
+		GM->ReturnToMenuWithDelay(1.0f);
+	}
+}
+
+void UGameOverWidget::OnLoadSaveButtonClicked()
+{
+
+}

--- a/Source/CR4S/UI/InGame/GameOverWidget.h
+++ b/Source/CR4S/UI/InGame/GameOverWidget.h
@@ -1,17 +1,39 @@
-// Fill out your copyright notice in the Description page of Project Settings.
-
 #pragma once
 
-#include "CoreMinimal.h"
 #include "Blueprint/UserWidget.h"
 #include "GameOverWidget.generated.h"
 
-/**
- * 
- */
+class UButtonWidget;
+
 UCLASS()
 class CR4S_API UGameOverWidget : public UUserWidget
 {
 	GENERATED_BODY()
 	
+#pragma region Constructors & Initiailizers
+
+	virtual void NativeConstruct() override;
+
+#pragma endregion
+
+#pragma region Widget Bindings
+protected:
+	UPROPERTY(meta = (BindWidget))
+	TObjectPtr<UButtonWidget> ToMenuButton;
+	UPROPERTY(meta = (BindWidget))
+	TObjectPtr<UButtonWidget> LoadSaveButton;
+
+	UPROPERTY(meta = (BindWidgetAnim), Transient)
+	UWidgetAnimation* ShowGameOverAnim;
+
+#pragma endregion
+
+public: 
+	void HandleGameOver();
+
+protected:
+	UFUNCTION()
+	void OnToMenuButtonClicked();
+	UFUNCTION()
+	void OnLoadSaveButtonClicked();
 };

--- a/Source/CR4S/UI/InGame/PauseWidget.cpp
+++ b/Source/CR4S/UI/InGame/PauseWidget.cpp
@@ -42,3 +42,4 @@ void UPauseWidget::OnToMenuButtonClicked()
 		GM->ReturnToMenu();
 	}
 }
+

--- a/Source/CR4S/UI/InGame/SurvivalHUD.h
+++ b/Source/CR4S/UI/InGame/SurvivalHUD.h
@@ -3,6 +3,8 @@
 #include "DefaultInGameWidget.h"
 #include "PauseWidget.h"
 #include "EndingSummaryWidget.h"
+#include "GameOverWidget.h"
+#include "UI/Common/LoadingWidget.h"
 #include "Components/SlateWrapperTypes.h"
 #include "GameFramework/HUD.h"
 #include "SurvivalHUD.generated.h"
@@ -53,7 +55,11 @@ protected:
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category="UI")
 	TSubclassOf<UPauseWidget> PauseWidgetClass;
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "UI")
+	TSubclassOf<UGameOverWidget> GameOverWidgetClass;
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "UI")
 	TSubclassOf<UEndingSummaryWidget> EndingSummaryWidgetClass;
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "UI")
+	TSubclassOf<ULoadingWidget> LoadingWidgetClass;
 
 #pragma endregion
 
@@ -63,6 +69,8 @@ protected:
 	TObjectPtr<UDefaultInGameWidget> InGameWidget;
 	UPROPERTY(VisibleDefaultsOnly, BlueprintReadOnly, Category = "UI")
 	TObjectPtr<UPauseWidget> PauseWidget;
+	UPROPERTY(VisibleDefaultsOnly, BlueprintReadOnly, Category = "UI")
+	TObjectPtr<UGameOverWidget> GameOverWidget;
 	UPROPERTY(VisibleDefaultsOnly, BlueprintReadOnly, Category = "UI")
 	TObjectPtr<UEndingSummaryWidget> EndingWidget;
 
@@ -77,17 +85,23 @@ public:
 	// Supports GameOnly, GameAndUI, and UIOnly modes with optional widget focus and mouse lock.
 	void SetInputMode(ESurvivalInputMode Mode, UUserWidget* FocusWidget = nullptr, bool bShowCursor = true, bool bLockMouse = false);
 
+	void ShowWidgetOnly(UUserWidget* TargetWidget);
 #pragma endregion
 
 #pragma region WidgetHandlers
 public:
 	UFUNCTION(BlueprintCallable) //for prototype
 	void HandlePauseToggle();
+	UFUNCTION(BlueprintCallable)
+	void HandleGameOverToggle();
 
+	void ShowLoading();
 	void PlayEndingSequence();
+	void BindGameOverWidget();
 
 #pragma endregion
 
 private:
 	virtual void BeginPlay() override;
+
 };


### PR DESCRIPTION
### ✅ 주요 변경 사항

1. **플레이어 사망 시 GameOverWidget 표시**  
   - HUD에 로딩 위젯 기능을 추가하여, 메뉴 복귀 시 로딩 연출이 적용되도록 개선.

---

### 💡 기타 참고 사항

- 사망 시에는 **"메인 메뉴" 버튼만 활성화**되어 있으며,  
  저장/불러오기 기능은 추후 **저장 시스템 통합 시** 함께 추가될 예정입니다.
