### PR TITLE
[Update] Inventory Container Widget

### DIFF
--- a/Content/CR4S/_Blueprint/UI/InGame/BP_SurvivalHUD.uasset
+++ b/Content/CR4S/_Blueprint/UI/InGame/BP_SurvivalHUD.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:41015137df993b0bf16a61a987da0631c063ac24591cc47f9653ef3d7e812cae
-size 25594
+oid sha256:059490277e5583d5f0c2bb1d62508066dbbd409fd6256aa98975bd72fc6c7570
+size 25520

--- a/Content/EasyBuildingSystem/Blueprints/Game/BP_EBS_PlayerController.uasset
+++ b/Content/EasyBuildingSystem/Blueprints/Game/BP_EBS_PlayerController.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8b13313e1f346e9c8df517316f9f611b0cac8e125eba66dc3bc8e3bc1e0d3237
-size 821639
+oid sha256:5b8aee17a32440a543040b704965444723e476b1fb95895bcbfe4ff30d35cea6
+size 821520

--- a/Source/CR4S/Inventory/Components/PlayerInventoryComponent.cpp
+++ b/Source/CR4S/Inventory/Components/PlayerInventoryComponent.cpp
@@ -37,9 +37,7 @@ void UPlayerInventoryComponent::BeginPlay()
 		return;
 	}
 
-	InventoryContainerWidgetInstance = SurvivalHUD->CreateAndAddWidget(InventoryContainerWidgetClass,
-	                                                                   0,
-	                                                                   ESlateVisibility::Visible);
+	InventoryContainerWidgetInstance = SurvivalHUD->GetInventoryContainerWidget();
 
 	if (CR4S_VALIDATE(LogInventory, IsValid(InventoryContainerWidgetInstance)))
 	{

--- a/Source/CR4S/UI/InGame/SurvivalHUD.cpp
+++ b/Source/CR4S/UI/InGame/SurvivalHUD.cpp
@@ -3,6 +3,7 @@
 #include "Character/Components/BaseStatusComponent.h"
 #include "Kismet/GameplayStatics.h"
 #include "GameFramework/Character.h"
+#include "Inventory/UI/InventoryContainerWidget.h"
 
 void ASurvivalHUD::BeginPlay()
 {
@@ -12,6 +13,8 @@ void ASurvivalHUD::BeginPlay()
 
 	PauseWidget = CreateAndAddWidget<UPauseWidget>(PauseWidgetClass, 10, ESlateVisibility::Collapsed);
 	PauseWidget->OnResumeRequested.BindUObject(this, &ASurvivalHUD::HandlePauseToggle);
+
+	InventoryContainerWidget = CreateAndAddWidget(InventoryContainerWidgetClass, 0, ESlateVisibility::Visible);
 
 	BindGameOverWidget();
 }
@@ -170,7 +173,7 @@ void ASurvivalHUD::SetInputMode(ESurvivalInputMode Mode, UUserWidget* FocusWidge
 
 void ASurvivalHUD::ShowWidgetOnly(UUserWidget* TargetWidget)
 {
-	TArray<UUserWidget*> AllWidgets = { InGameWidget, PauseWidget, GameOverWidget, EndingWidget };
+	TArray<UUserWidget*> AllWidgets = { InGameWidget, PauseWidget, GameOverWidget, EndingWidget, InventoryContainerWidget };
 
 	for (UUserWidget* Widget : AllWidgets)
 	{

--- a/Source/CR4S/UI/InGame/SurvivalHUD.h
+++ b/Source/CR4S/UI/InGame/SurvivalHUD.h
@@ -10,6 +10,8 @@
 #include "GameFramework/HUD.h"
 #include "SurvivalHUD.generated.h"
 
+class UInventoryContainerWidget;
+
 enum class ESurvivalInputMode
 {
 	GameOnly,
@@ -25,6 +27,8 @@ class CR4S_API ASurvivalHUD : public AHUD
 public:
 	UFUNCTION(BlueprintCallable)
 	FORCEINLINE UDefaultInGameWidget* GetInGameWidget() const { return InGameWidget; }
+	UFUNCTION(BlueprintCallable)
+	FORCEINLINE UInventoryContainerWidget* GetInventoryContainerWidget() const { return InventoryContainerWidget; }
 
 #pragma region WidgetSetting
 public:
@@ -63,6 +67,8 @@ protected:
 	TSubclassOf<ULoadingWidget> LoadingWidgetClass;
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "UI")
 	TSubclassOf<UNotificationWidget> NotificationWidgetClass;
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "UI")
+	TSubclassOf<UInventoryContainerWidget> InventoryContainerWidgetClass;
 
 
 #pragma endregion
@@ -79,6 +85,8 @@ protected:
 	TObjectPtr<UEndingSummaryWidget> EndingWidget;
 	UPROPERTY(VisibleDefaultsOnly, BlueprintReadOnly, Category = "UI")
 	TObjectPtr<UNotificationWidget> NotificationWidget;
+	UPROPERTY(VisibleDefaultsOnly, BlueprintReadOnly, Category = "UI")
+	TObjectPtr<UInventoryContainerWidget> InventoryContainerWidget;
 
 #pragma endregion
 


### PR DESCRIPTION
- SurvivalHUD 블루프린트에 인벤토리 컨테이너 위젯 클래스 등록하여 해당 위젯 생성
- EBSPlayerController 에서 DefaultInGameWidget이 토글 될 때 인벤토리 컨테이너 위젯도 같이 반응하도록 함.
  - 인벤토리가 열리고 닫힐 때마다 한번 위젯을 떼었다가 붙이기 때문에 InGameWidget에 포함 시켜 사용하기 어렵다고 판단하여 간단하게 별도로 켜주는 로직을 추가함
  - 끄는 로직은 코드 내에서 한번에 꺼지도록 했음