### PR TITLE
[Chore] Add Spawanable Interface to CropsGimmick

### DIFF
--- a/Source/CR4S/FriendlyAI/BaseAnimal.cpp
+++ b/Source/CR4S/FriendlyAI/BaseAnimal.cpp
@@ -404,7 +404,7 @@ void ABaseAnimal::Die()
         ActiveInteractWidget->RemoveFromParent();
         ActiveInteractWidget = nullptr;
     }
-    OnDied.Broadcast(this);
+    OnSpawnableDestroyed.Broadcast(this);
 
     if (AAIController* AIController = Cast<AAIController>(GetController()))
     {

--- a/Source/CR4S/FriendlyAI/BaseAnimal.h
+++ b/Source/CR4S/FriendlyAI/BaseAnimal.h
@@ -125,10 +125,10 @@ public:
 	virtual void SetAnimalState(EAnimalState NewState);
 	void ClearTarget();
 
-	FOnDied OnDied;
+	FOnSpawnableDestroyed OnSpawnableDestroyed;
 
 	//Function to Return OnDied Delegate by Spawnable Interface
-	virtual FOnDied* GetOnDiedDelegate() override { return &OnDied; }
+	virtual FOnSpawnableDestroyed* GetOnSpawnableDestroyedDelegate() override { return &OnSpawnableDestroyed; }
 
 public:
 		

--- a/Source/CR4S/Game/Interface/Spawnable.h
+++ b/Source/CR4S/Game/Interface/Spawnable.h
@@ -3,7 +3,7 @@
 #include "UObject/Interface.h"
 #include "Spawnable.generated.h"
 
-DECLARE_MULTICAST_DELEGATE_OneParam(FOnDied, AActor*);
+DECLARE_MULTICAST_DELEGATE_OneParam(FOnSpawnableDestroyed, AActor*);
 
 UINTERFACE(MinimalAPI)
 class USpawnable : public UInterface 
@@ -16,5 +16,5 @@ class CR4S_API ISpawnable
 	GENERATED_BODY()
 
 public:
-	virtual FOnDied* GetOnDiedDelegate() = 0;
+	virtual FOnSpawnableDestroyed* GetOnSpawnableDestroyedDelegate() = 0;
 };

--- a/Source/CR4S/Game/System/SpawnZoneVolume.cpp
+++ b/Source/CR4S/Game/System/SpawnZoneVolume.cpp
@@ -94,7 +94,7 @@ AActor* ASpawnZoneVolume::SpawnActorsAndTrack(TSubclassOf<AActor> SpawnClass, co
             ISpawnable* Spawnable = Cast<ISpawnable>(Spawned);
             if (Spawnable)
             {
-                if (FOnDied* Delegate = Spawnable->GetOnDiedDelegate())
+                if (FOnSpawnableDestroyed* Delegate = Spawnable->GetOnSpawnableDestroyedDelegate())
                 {
                     Delegate->AddUObject(this, &ASpawnZoneVolume::HandleActorDeath);
                 }
@@ -220,7 +220,7 @@ void ASpawnZoneVolume::SpawnCrops()
                     SpawnLocation = FVector(RandomPoint2D.X, RandomPoint2D.Y, SpawnHeight);
                 }
 
-                AActor* Spawned = GetWorld()->SpawnActor<AActor>(SpawnInfo.SpawnClass, SpawnLocation, FRotator::ZeroRotator);
+                AActor* Spawned = SpawnActorsAndTrack(SpawnInfo.SpawnClass, SpawnLocation);
                 if (Spawned)
                 {
                     SpawnedActors.Add(Spawned);
@@ -229,6 +229,7 @@ void ASpawnZoneVolume::SpawnCrops()
         }
     }
 }
+
 
 
 void ASpawnZoneVolume::DespawnActorsInZone()

--- a/Source/CR4S/Gimmick/GimmickObjects/Farming/CropsGimmick.cpp
+++ b/Source/CR4S/Gimmick/GimmickObjects/Farming/CropsGimmick.cpp
@@ -137,6 +137,7 @@ void ACropsGimmick::Harvest(const AActor* Interactor)
 
 	GetResources(Interactor);
 
+	OnSpawnableDestroyed.Broadcast(this);
 	GimmickDestroy();
 }
 

--- a/Source/CR4S/Gimmick/GimmickObjects/Farming/CropsGimmick.h
+++ b/Source/CR4S/Gimmick/GimmickObjects/Farming/CropsGimmick.h
@@ -2,13 +2,13 @@
 
 #include "CoreMinimal.h"
 #include "Gimmick/Data/GimmickData.h"
+#include "Game/Interface/Spawnable.h"
 #include "Gimmick/GimmickObjects/BaseGimmick.h"
 #include "CropsGimmick.generated.h"
 
 class AEnvironmentManager;
 class UEnvironmentalStatusComponent;
 class UInteractableComponent;
-
 USTRUCT(BlueprintType)
 struct FCropsGimmickGrowthData
 {
@@ -35,7 +35,7 @@ struct FCropsGimmickGrowthData
 };
 
 UCLASS(BlueprintType)
-class CR4S_API ACropsGimmick : public ABaseGimmick
+class CR4S_API ACropsGimmick : public ABaseGimmick, public ISpawnable
 {
 	GENERATED_BODY()
 
@@ -195,6 +195,12 @@ public:
 
 	UFUNCTION(BlueprintCallable, Category = "CropsGimmick|LoadGame")
 	void LoadPlantedCropsGimmick(const FCropsGimmickGrowthData& NewCropsGimmickData);
+
+#pragma endregion
+	 
+#pragma region Spawn
+	virtual FOnSpawnableDestroyed* GetOnSpawnableDestroyedDelegate() override { return &OnSpawnableDestroyed; }
+	FOnSpawnableDestroyed OnSpawnableDestroyed;
 
 #pragma endregion
 };

--- a/Source/CR4S/MonsterAI/BaseMonster.h
+++ b/Source/CR4S/MonsterAI/BaseMonster.h
@@ -132,9 +132,9 @@ protected:
 	UFUNCTION()
 	virtual void OnMonsterStateChanged(EMonsterState Previous, EMonsterState Current);
 	
-	virtual FOnDied* GetOnDiedDelegate() override { return &OnDied; }
+	virtual FOnSpawnableDestroyed* GetOnSpawnableDestroyedDelegate() override { return &OnDied; }
 	
-	FOnDied OnDied;
+	FOnSpawnableDestroyed OnDied;
 
 #pragma endregion
 


### PR DESCRIPTION
### 주요 변경 사항

1. **작물 기믹에 리스폰 가능 인터페이스(`ISpawnable`) 추가**  
   - `ACropsGimmick` 클래스가 `ISpawnable` 인터페이스를 구현하여 `SpawnZoneVolume`의 리스폰 시스템과 연동 가능하도록 수정
   - 수확 시 `OnSpawnableDestroyed` 델리게이트 호출 필요

2. **델리게이트 이름 변경**  
   - 인터페이스 델리게이트 명확화를 위해 `FOnDied` → `FOnSpawnableDestroyed`로 변경
   - 관련 클래스 및 include 경로 전반적으로 수정

---

### 기타 참고 사항
