### PR TITLE
[Add] Robot Workshop Tooltip / [BugFix] Player Inventory Load

### DIFF
--- a/Content/CR4S/_Blueprint/UI/Crafting/WBP_Crafting.uasset
+++ b/Content/CR4S/_Blueprint/UI/Crafting/WBP_Crafting.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8bc631a83c47be3dd17b934a3bb5dd32e50374510a17e2d0b91839dd8dbcbd66
-size 83145
+oid sha256:842b288c500b4cbd74f10df2ade63f4d569c66d6bd3c059503cc3a4fef984c89
+size 83370

--- a/Content/CR4S/_Blueprint/UI/Gimmick/WBP_RobotWorkshop.uasset
+++ b/Content/CR4S/_Blueprint/UI/Gimmick/WBP_RobotWorkshop.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:989700eead97a41e28d7e8dbfc9b51dcaa85aba6be627d84eead861719c8d1fc
-size 140960
+oid sha256:6f3c37934558b2cf9591a72841b88540b2148cf09b77bd3a81bbb77e6a53e10b
+size 141176

--- a/Source/CR4S/Character/Characters/PlayerCharacter.cpp
+++ b/Source/CR4S/Character/Characters/PlayerCharacter.cpp
@@ -328,6 +328,7 @@ void APlayerCharacter::PossessedBy(AController* NewController)
 	InitializeWidgets();
 	Status->SetIsUnPossessed(false);
 
+	PlayerInventory->InitInventory();
 }
 
 void APlayerCharacter::UnPossessed()

--- a/Source/CR4S/Gimmick/GimmickObjects/BaseDestructObject.cpp
+++ b/Source/CR4S/Gimmick/GimmickObjects/BaseDestructObject.cpp
@@ -15,6 +15,7 @@ ABaseDestructObject::ABaseDestructObject()
 	SetRootComponent(GeometryCollectionComponent);
 	
 	GeometryCollectionComponent->DamageThreshold.Init(0.f, 1);
+	GeometryCollectionComponent->SetCollisionResponseToChannel(ECC_Visibility, ECR_Ignore);
 	GeometryCollectionComponent->SetCollisionResponseToChannel(ECC_WorldDynamic, ECR_Ignore);
 	GeometryCollectionComponent->SetCollisionResponseToChannel(ECC_Pawn, ECR_Ignore);
 	GeometryCollectionComponent->SetCollisionResponseToChannel(ECC_PhysicsBody, ECR_Ignore);

--- a/Source/CR4S/Gimmick/GimmickObjects/Farming/CropsGimmick.cpp
+++ b/Source/CR4S/Gimmick/GimmickObjects/Farming/CropsGimmick.cpp
@@ -79,6 +79,7 @@ void ACropsGimmick::InitCollisionSetting() const
 	if (IsValid(GimmickMeshComponent))
 	{
 		GimmickMeshComponent->SetCollisionResponseToChannel(ECC_WorldDynamic, ECR_Overlap);
+		GimmickMeshComponent->SetCollisionResponseToChannel(ECC_Visibility, ECR_Ignore);
 		GimmickMeshComponent->SetCollisionResponseToChannel(ECC_Pawn, ECR_Ignore);
 		GimmickMeshComponent->SetCollisionResponseToChannel(ECC_PhysicsBody, ECR_Ignore);
 	}

--- a/Source/CR4S/Gimmick/Manager/ItemGimmickSubsystem.cpp
+++ b/Source/CR4S/Gimmick/Manager/ItemGimmickSubsystem.cpp
@@ -7,7 +7,12 @@
 #include "Gimmick/GimmickObjects/BaseGimmick.h"
 #include "Gimmick/GimmickObjects/ItemPouchGimmick.h"
 #include "Gimmick/GimmickObjects/Farming/CropsGimmick.h"
+#include "Inventory/InventoryItem/ConsumableInventoryItem.h"
+#include "Inventory/InventoryItem/HelperBotInventoryItem.h"
+#include "Inventory/InventoryItem/RobotPartsInventoryItem.h"
+#include "Inventory/InventoryItem/ToolInventoryItem.h"
 #include "Kismet/GameplayStatics.h"
+#include "Utility/Cr4sGameplayTags.h"
 
 UItemGimmickSubsystem::UItemGimmickSubsystem()
 	: ItemInfoDataTable(nullptr)
@@ -71,6 +76,31 @@ const FGimmickInfoData* UItemGimmickSubsystem::FindGimmickInfoData(const FName& 
 void UItemGimmickSubsystem::GetGimmickInfoData(const FName& RowName, FGimmickInfoData& OutGimmickInfoData) const
 {
 	OutGimmickInfoData = *FindGimmickInfoData(RowName);
+}
+
+UBaseInventoryItem* UItemGimmickSubsystem::CreateInventoryItem(UObject* Outer, const FGameplayTagContainer& ItemTags)
+{
+	if (ItemTags.HasTag(ItemTags::Tools))
+	{
+		return NewObject<UToolInventoryItem>(Outer);
+	}
+	
+	if (ItemTags.HasTag(ItemTags::Consumable))
+	{
+		return NewObject<UConsumableInventoryItem>(Outer);
+	}
+	
+	if (ItemTags.HasTag(ItemTags::HelperBot))
+	{
+		return NewObject<UHelperBotInventoryItem>(Outer);
+	}
+
+	if (ItemTags.HasTag(ItemTags::RobotParts) || ItemTags.HasTag(ItemTags::Weapon))
+	{
+		return NewObject<URobotPartsInventoryItem>(Outer);
+	}
+
+	return NewObject<UBaseInventoryItem>(Outer);
 }
 
 void UItemGimmickSubsystem::SpawnItemPouch(const AActor* SourceActor, const TMap<FName, int32>& RemainingItems,

--- a/Source/CR4S/Gimmick/Manager/ItemGimmickSubsystem.h
+++ b/Source/CR4S/Gimmick/Manager/ItemGimmickSubsystem.h
@@ -7,6 +7,7 @@
 
 #include "ItemGimmickSubsystem.generated.h"
 
+class UBaseInventoryItem;
 class USaveGame;
 class UProjectilePoolSubsystem;
 struct FGimmickSaveGameData;
@@ -62,6 +63,13 @@ private:
 
 #pragma endregion
 
+#pragma region Create Inventory Item
+
+public:
+	static UBaseInventoryItem* CreateInventoryItem(UObject* Outer, const FGameplayTagContainer& ItemTags);
+	
+#pragma endregion 
+	
 #pragma region Gimmick Spawn
 
 public:

--- a/Source/CR4S/Gimmick/UI/BedWidget.cpp
+++ b/Source/CR4S/Gimmick/UI/BedWidget.cpp
@@ -70,9 +70,9 @@ void UBedWidget::PlaySleepingAnimation_Implementation()
 		{
 			SurvivalHUD->SetInputMode(ESurvivalInputMode::UIOnly, this, false);
 		}
-
+	
 		PlayAnimation(SleepingAnim, 0.f, 1, EUMGSequencePlayMode::Forward);
-
+	
 		bIsSleeping = true;
 	}
 }

--- a/Source/CR4S/Inventory/Components/BaseInventoryComponent.cpp
+++ b/Source/CR4S/Inventory/Components/BaseInventoryComponent.cpp
@@ -8,9 +8,6 @@
 #include "Inventory/InventoryItem/BaseInventoryItem.h"
 #include "Inventory/InventoryItem/ConsumableInventoryItem.h"
 #include "Inventory/InventoryItem/HelperBotInventoryItem.h"
-#include "Inventory/InventoryItem/RobotPartsInventoryItem.h"
-#include "Inventory/InventoryItem/ToolInventoryItem.h"
-#include "Utility/Cr4sGameplayTags.h"
 
 UBaseInventoryComponent::UBaseInventoryComponent()
 	: MaxInventorySize(10),
@@ -171,7 +168,7 @@ void UBaseInventoryComponent::StackItemsAndFillEmptySlots(const FName RowName,
 				continue;
 			}
 
-			UBaseInventoryItem* EmptyInventoryItem = CreateInventoryItem(ItemData->ItemTags);
+			UBaseInventoryItem* EmptyInventoryItem = UItemGimmickSubsystem::CreateInventoryItem(this, ItemData->ItemTags);
 			if (!CR4S_VALIDATE(LogInventory, EmptyInventoryItem))
 			{
 				continue;
@@ -245,31 +242,6 @@ bool UBaseInventoryComponent::CheckRottenItem(UBaseInventoryItem* OriginItem, UB
 	return TargetConsumableInventoryItem->IsRotten();
 }
 
-UBaseInventoryItem* UBaseInventoryComponent::CreateInventoryItem(const FGameplayTagContainer& ItemTags)
-{
-	if (ItemTags.HasTag(ItemTags::Tools))
-	{
-		return NewObject<UToolInventoryItem>(this);
-	}
-	
-	if (ItemTags.HasTag(ItemTags::Consumable))
-	{
-		return NewObject<UConsumableInventoryItem>(this);
-	}
-	
-	if (ItemTags.HasTag(ItemTags::HelperBot))
-	{
-		return NewObject<UHelperBotInventoryItem>(this);
-	}
-
-	if (ItemTags.HasTag(ItemTags::RobotParts) || ItemTags.HasTag(ItemTags::Weapon))
-	{
-		return NewObject<URobotPartsInventoryItem>(this);
-	}
-
-	return NewObject<UBaseInventoryItem>(this);
-}
-
 bool UBaseInventoryComponent::IsItemAllowedByFilter(const FGameplayTagContainer& ItemTags) const
 {
 	if (!IsValid(FilterData))
@@ -304,7 +276,7 @@ void UBaseInventoryComponent::LoadInventorySaveGame(const FInventorySaveGame& Sa
 		const int32 Index = SaveItemData.InventoryItemData.SlotIndex;
 
 		const FGameplayTagContainer& Tags = SaveItemData.InventoryItemData.ItemInfoData.ItemTags;
-		UBaseInventoryItem* Item = CreateInventoryItem(Tags);
+		UBaseInventoryItem* Item = UItemGimmickSubsystem::CreateInventoryItem(this, Tags);
 		Item->LoadInventoryItemSaveData(this, SaveItemData);
 		InventoryItems[Index] = Item;
 

--- a/Source/CR4S/Inventory/Components/BaseInventoryComponent.h
+++ b/Source/CR4S/Inventory/Components/BaseInventoryComponent.h
@@ -48,7 +48,7 @@ public:
 #pragma region Initialize
 
 public:
-	void InitInventory();
+	virtual void InitInventory();
 
 #pragma endregion
 
@@ -138,7 +138,7 @@ protected:
 	                                 TSet<int32>& ChangedItemSlots,
 	                                 UBaseInventoryItem* OriginItem);
 
-	UBaseInventoryItem* CreateInventoryItem(const FGameplayTagContainer& ItemTags);
+
 	UPROPERTY(EditDefaultsOnly, Category = "InventorySystem")
 	int32 MaxInventorySize;
 

--- a/Source/CR4S/Inventory/Components/PlayerInventoryComponent.cpp
+++ b/Source/CR4S/Inventory/Components/PlayerInventoryComponent.cpp
@@ -16,9 +16,9 @@ UPlayerInventoryComponent::UPlayerInventoryComponent()
 	MaxInventorySize = 50;
 }
 
-void UPlayerInventoryComponent::BeginPlay()
+void UPlayerInventoryComponent::InitInventory()
 {
-	Super::BeginPlay();
+	Super::InitInventory();
 
 	QuickSlotInventoryComponent = NewObject<UBaseInventoryComponent>(this);
 	QuickSlotInventoryComponent->SetMaxInventorySize(10);

--- a/Source/CR4S/Inventory/Components/PlayerInventoryComponent.h
+++ b/Source/CR4S/Inventory/Components/PlayerInventoryComponent.h
@@ -19,14 +19,15 @@ class CR4S_API UPlayerInventoryComponent : public UBaseInventoryComponent
 
 public:
 	UPlayerInventoryComponent();
-
-	virtual void BeginPlay() override;
+	
+	virtual void InitInventory() override;
 
 	virtual FAddItemResult AddItem(FName RowName, int32 Count, UBaseInventoryItem* OriginItem = nullptr) override;
 
 	virtual int32 RemoveItemByRowName(const FName RowName, const int32 Count) override;
 	virtual void RemoveAllItemByRowName(const FName RowName) override;
 	virtual int32 GetItemCountByRowName(const FName RowName) const override;
+
 
 #pragma endregion
 

--- a/Source/CR4S/Inventory/InventoryItem/BaseInventoryItem.cpp
+++ b/Source/CR4S/Inventory/InventoryItem/BaseInventoryItem.cpp
@@ -7,7 +7,6 @@
 #include "Game/System/WorldTimeManager.h"
 #include "Inventory/Components/BaseInventoryComponent.h"
 #include "Inventory/Components/PlayerInventoryComponent.h"
-#include "Kismet/GameplayStatics.h"
 
 UBaseInventoryItem::UBaseInventoryItem()
 	: bUsePassiveEffect(false),

--- a/Source/CR4S/Inventory/InventoryItem/BaseInventoryItem.h
+++ b/Source/CR4S/Inventory/InventoryItem/BaseInventoryItem.h
@@ -1,6 +1,7 @@
 ﻿#pragma once
 
 #include "CoreMinimal.h"
+#include "Game/SaveGame/InventorySaveGame.h"
 #include "Gimmick/Data/ItemData.h"
 #include "Inventory/Data/InventoryItemData.h"
 #include "UObject/Object.h"
@@ -101,6 +102,11 @@ public:
 		InventoryItemData.ItemInfoData.Description = NewDescription;
 	}
 
+	FORCEINLINE void SetItemInfoData(const FItemInfoData& NewItemInfoData)
+	{
+		InventoryItemData.ItemInfoData = NewItemInfoData;
+	}
+
 protected:
 	UPROPERTY(VisibleAnywhere, Category = "InventoryItem")
 	FInventoryItemData InventoryItemData;
@@ -115,8 +121,9 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "InventoryItem|SaveData")
 	virtual FInventoryItemSaveGame GetInventoryItemSaveData();
 	UFUNCTION(BlueprintCallable, Category = "InventoryItem|LoadData")
-	virtual void LoadInventoryItemSaveData(UBaseInventoryComponent* NewInventoryComponent, const FInventoryItemSaveGame& ItemSaveGame);
-	
+	virtual void LoadInventoryItemSaveData(UBaseInventoryComponent* NewInventoryComponent,
+	                                       const FInventoryItemSaveGame& ItemSaveGame);
+
 #pragma endregion
 
 #pragma region Delegate

--- a/Source/CR4S/Inventory/InventoryItem/RobotPartsInventoryItem.h
+++ b/Source/CR4S/Inventory/InventoryItem/RobotPartsInventoryItem.h
@@ -20,8 +20,9 @@ public:
 
 #pragma region Data
 
-private:
+public:
 	void InitTextFormat();
+private:
 	void InitRobotPartsInfoData(const FGameplayTag& Tag);
 
 	FTextFormat TextFormat;

--- a/Source/CR4S/Inventory/InventoryItem/ToolInventoryItem.cpp
+++ b/Source/CR4S/Inventory/InventoryItem/ToolInventoryItem.cpp
@@ -18,10 +18,10 @@ void UToolInventoryItem::InitInventoryItem(UBaseInventoryComponent* NewInventory
 {
 	Super::InitInventoryItem(NewInventoryComponent, NewInventoryItemData, StackCount);
 
-	const APawn* Pawn = UGameplayStatics::GetPlayerPawn(GetWorld(), 0);
-	if (IsValid(Pawn))
+	const AActor* PlayerCharacter = UGameplayStatics::GetActorOfClass(GetWorld(), APlayerCharacter::StaticClass());
+	if (IsValid(PlayerCharacter))
 	{
-		PlayerInventoryComponent = Pawn->FindComponentByClass<UPlayerInventoryComponent>();
+		PlayerInventoryComponent = PlayerCharacter->FindComponentByClass<UPlayerInventoryComponent>();
 	}
 	
 	const UDataTable* DataTable = NewInventoryItemData.ItemInfoData.DetailData.DataTable;

--- a/Source/CR4S/Inventory/UI/InventoryContainerWidget.h
+++ b/Source/CR4S/Inventory/UI/InventoryContainerWidget.h
@@ -35,7 +35,7 @@ public:
 
 public:
 	void InitWidget(ASurvivalHUD* InSurvivalHUD, UPlayerInventoryComponent* InPlayerInventoryComponent);
-
+	
 	FORCEINLINE UPlayerInventoryComponent* GetPlayerInventoryComponent() const { return PlayerInventoryComponent; }
 
 private:

--- a/Source/CR4S/Inventory/UI/InventoryWidget/RobotInventoryWidget.cpp
+++ b/Source/CR4S/Inventory/UI/InventoryWidget/RobotInventoryWidget.cpp
@@ -7,6 +7,7 @@
 #include "Inventory/UI/ItemSlotWidget/RobotPartsItemSlotWidget.h"
 #include "UI/Crafting/CraftingWidget.h"
 #include "UI/Crafting/RecipeSelectWidget.h"
+#include "Utility/Cr4sGameplayTags.h"
 
 void URobotInventoryWidget::NativeConstruct()
 {
@@ -43,6 +44,7 @@ void URobotInventoryWidget::InitWidget(ASurvivalHUD* SurvivalHUD, const bool bNe
 	if (IsValid(CraftingWidget) && IsValid(InventoryContainerWidget))
 	{
 		CraftingWidget->InitWidget(InventoryContainerWidget->GetPlayerInventoryComponent());
+		CraftingWidget->CreateResultItem(FGameplayTagContainer(FGameplayTag(ItemTags::RobotParts)));
 	}
 }
 

--- a/Source/CR4S/Inventory/UI/ItemSlotWidget/BaseItemSlotWidget.cpp
+++ b/Source/CR4S/Inventory/UI/ItemSlotWidget/BaseItemSlotWidget.cpp
@@ -34,9 +34,6 @@ UBaseItemSlotWidget::UBaseItemSlotWidget(const FObjectInitializer& ObjectInitial
 	  bCanRightClick(true),
 	  bCanRemoveItem(true),
 	  bCanMoveItem(true),
-	  LongPressThreshold(0.5f),
-	  PressStartTime(0.0),
-	  bLongPressTriggered(false),
 	  bCanUseItemTooltip(true)
 {
 }
@@ -234,67 +231,12 @@ FReply UBaseItemSlotWidget::NativeOnMouseButtonDown(const FGeometry& InGeometry,
 		return FReply::Unhandled();
 	}
 
-	if (bCanRightClick && InMouseEvent.GetEffectingButton() == EKeys::RightMouseButton)
-	{
-		bLongPressTriggered = false;
-
-		if (GetWorld())
-		{
-			GetWorld()->GetTimerManager().SetTimer(
-				LongPressTimerHandle,
-				this,
-				&ThisClass::OnLongPressDetected,
-				LongPressThreshold,
-				false
-			);
-		}
-
-		PressStartTime = FPlatformTime::Seconds();
-
-		return FReply::Handled().PreventThrottling();
-	}
-
-
 	if (InMouseEvent.IsMouseButtonDown(EKeys::LeftMouseButton))
 	{
 		return UWidgetBlueprintLibrary::DetectDragIfPressed(InMouseEvent, this, EKeys::LeftMouseButton).NativeReply;
 	}
 
 	return Super::NativeOnMouseButtonDown(InGeometry, InMouseEvent);
-}
-
-FReply UBaseItemSlotWidget::NativeOnMouseButtonUp(const FGeometry& InGeometry, const FPointerEvent& InMouseEvent)
-{
-	if (!IsValid(CurrentItem))
-	{
-		return FReply::Unhandled();
-	}
-
-	if (InMouseEvent.GetEffectingButton() == EKeys::RightMouseButton)
-	{
-		if (GetWorld() && GetWorld()->GetTimerManager().IsTimerActive(LongPressTimerHandle))
-		{
-			GetWorld()->GetTimerManager().ClearTimer(LongPressTimerHandle);
-			OnShortClick();
-		}
-		else if (!bLongPressTriggered)
-		{
-			const double Duration = FPlatformTime::Seconds() - PressStartTime;
-			if (Duration >= LongPressThreshold)
-			{
-				bLongPressTriggered = true;
-				OnLongPress();
-			}
-			else
-			{
-				OnShortClick();
-			}
-		}
-
-		return FReply::Handled();
-	}
-
-	return Super::NativeOnMouseButtonUp(InGeometry, InMouseEvent);
 }
 
 void UBaseItemSlotWidget::NativeOnDragDetected(const FGeometry& InGeometry, const FPointerEvent& InMouseEvent,
@@ -416,22 +358,6 @@ void UBaseItemSlotWidget::UnEquipItem(const UBaseInventoryComponent* QuickSlotIn
 			ToolItem->UnEquipItem();
 		}
 	}
-}
-
-void UBaseItemSlotWidget::OnShortClick()
-{
-	CR4S_Log(LogInventoryUI, Warning, TEXT("ShortClick!"));
-}
-
-void UBaseItemSlotWidget::OnLongPressDetected()
-{
-	bLongPressTriggered = true;
-	OnLongPress();
-}
-
-void UBaseItemSlotWidget::OnLongPress()
-{
-	CR4S_Log(LogInventoryUI, Warning, TEXT("LongPressed!!!"));
 }
 
 UWidget* UBaseItemSlotWidget::ShowToolTip()

--- a/Source/CR4S/Inventory/UI/ItemSlotWidget/BaseItemSlotWidget.h
+++ b/Source/CR4S/Inventory/UI/ItemSlotWidget/BaseItemSlotWidget.h
@@ -116,7 +116,6 @@ public:
 
 protected:
 	virtual FReply NativeOnMouseButtonDown(const FGeometry& InGeometry, const FPointerEvent& InMouseEvent) override;
-	virtual FReply NativeOnMouseButtonUp(const FGeometry& InGeometry, const FPointerEvent& InMouseEvent) override;
 	virtual void NativeOnDragDetected(const FGeometry& InGeometry, const FPointerEvent& InMouseEvent,
 	                                  UDragDropOperation*& OutOperation) override;
 	virtual bool NativeOnDrop(const FGeometry& InGeometry, const FDragDropEvent& InDragDropEvent,
@@ -151,24 +150,6 @@ protected:
 	static const TArray<FKey> QuickSlotKeys;
 	
 #pragma endregion
-
-#pragma region DivideItem
-	
-protected:
-	void OnShortClick();
-	void OnLongPressDetected();
-	void OnLongPress();
-	
-	UPROPERTY(EditDefaultsOnly, Category="Input")
-	float LongPressThreshold;
-	
-	FTimerHandle LongPressTimerHandle;
-	
-	double PressStartTime;
-	
-	bool bLongPressTriggered;
-	
-#pragma endregion 
 
 #pragma region ToolTip
 

--- a/Source/CR4S/Inventory/UI/ItemTooltipWidget.h
+++ b/Source/CR4S/Inventory/UI/ItemTooltipWidget.h
@@ -2,12 +2,12 @@
 
 #include "CoreMinimal.h"
 #include "Blueprint/UserWidget.h"
+#include "Gimmick/Data/ItemData.h"
 #include "ItemTooltipWidget.generated.h"
 
 class UBaseInventoryItem;
 class UTextBlock;
 class UImage;
-struct FItemInfoData;
 
 UCLASS()
 class CR4S_API UItemTooltipWidget : public UUserWidget

--- a/Source/CR4S/UI/Crafting/CraftingWidget.h
+++ b/Source/CR4S/UI/Crafting/CraftingWidget.h
@@ -3,14 +3,14 @@
 #include "CoreMinimal.h"
 #include "IngredientsWidget.h"
 #include "Blueprint/UserWidget.h"
+#include "Gimmick/Data/ItemData.h"
 #include "Gimmick/Data/ItemRecipeData.h"
 #include "Inventory/Components/PlayerInventoryComponent.h"
 
 #include "CraftingWidget.generated.h"
 
-struct FRecipeIngredient;
-class UButton;
 struct FRecipeSelectData;
+class UButton;
 class UIngredientsWidget;
 class UCraftingContainerWidget;
 class UTextBlock;
@@ -25,6 +25,8 @@ class CR4S_API UCraftingWidget : public UUserWidget
 
 public:
 	UCraftingWidget(const FObjectInitializer& ObjectInitializer);
+
+	virtual void NativeConstruct() override;
 	
 #pragma endregion 
 	
@@ -32,6 +34,7 @@ public:
 
 public:
 	void InitWidget(UPlayerInventoryComponent* NewPlayerInventoryComponent);
+	void UpdateResultItem() const;
 
 private:
 	UPROPERTY()
@@ -68,6 +71,9 @@ private:
 
 #pragma region Crafting
 
+public:
+	void CreateResultItem(const FGameplayTagContainer& ItemTags);
+	
 private:
 	UFUNCTION()
 	void CraftItem();
@@ -82,8 +88,25 @@ private:
 	FItemRecipeData ItemRecipeData;
 
 	TArray<FIngredientData> CurrentIngredients;
+
+	UPROPERTY()
+	TObjectPtr<UBaseInventoryItem> ResultItem;
 	
 #pragma endregion
+
+#pragma region Tooltip
+
+private:
+	UFUNCTION()
+	UWidget* ShowToolTip();
+
+	UPROPERTY(EditDefaultsOnly, Category = "ItemTooltip")
+	TSubclassOf<UItemTooltipWidget> ItemTooltipWidgetClass;
+
+	UPROPERTY()
+	TObjectPtr<UItemTooltipWidget> ItemTooltipWidget;
+	
+#pragma endregion 
 
 #pragma region Delegate
 


### PR DESCRIPTION
- 로봇 정비소 툴팁 추가 -> 제작할 파츠 정보 확인

- 게임 불러오기 할 때 플레이어 인벤토리 컴포넌트 연동이 끊기는 버그 수정
  - 원인: 플레이어 인벤토리 컴포넌트 자체는 제대로 생성되지만 위젯과 연동 되는 부분이 끊겨버림 -> 플레이어가 제거되고 다시 생성되면서 발생하는 문제로 캐릭터가 빙의 되기전에 인벤토리 컴포넌트가 초기화를 시도하고 컨트롤러를 못찾아서 버그 발생
  - 해결: 캐릭터가 컨트롤러에 빙의된 이후에 인벤토리 컴포넌트 초기화를 한번 더 실행 해줌