### PR TITLE
[Fix] Fix animal and item tables

### DIFF
--- a/Content/CR4S/_Data/AnimalStatsTable.uasset
+++ b/Content/CR4S/_Data/AnimalStatsTable.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9f801048d9049c0e0754d131d7b8bb7a5776c240c5ef03e2be45c325e12ce6f2
-size 9169
+oid sha256:8c7d92b2373fd065bdb5a714e61af425922d1447eb9bf0abcbd194becec584cc
+size 9197

--- a/Content/CR4S/_Data/Item/DT_ItemRecipeData.uasset
+++ b/Content/CR4S/_Data/Item/DT_ItemRecipeData.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:228fd26777895133df626d5fcc392cb0b69f39b1482af154c0673bf80a9687c7
-size 81763
+oid sha256:725fa35a59d793a1c3e2164a81bab2863c524a6baebb9aaa872b23c4a611139a
+size 81727

--- a/Content/CR4S/_Map/MainMap.umap
+++ b/Content/CR4S/_Map/MainMap.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:13e41fe8b57cc3a9813e00a16a26b5f50b6ae5bbb949a4f54e4ffd8b4034e118
-size 140770975
+oid sha256:f4d353b4958bcf873bfb84f58ac6eaf2087c493cc0852e3ba3a6661a8a66c73e
+size 140770247


### PR DESCRIPTION
맵 세팅 및 데이터 수정

-맵: 초만 평야 지역 늑대 스폰 제거
-데이터 수정: 동물 스텟 수치 조정, 
 아이템 테이블 현재 없는 재료->0으로 변경 (여우 꼬리), 털 드랍 추가(사슴, 토끼)