### PR TITLE
[Fix] Invalid attachment position when robot boarding in a sitting posture.

### DIFF
--- a/Config/DefaultGameplayTags.ini
+++ b/Config/DefaultGameplayTags.ini
@@ -13,6 +13,7 @@ InvalidTagCharacters="\"\',"
 +GameplayTagRedirects=(OldTagName="Item.Crops",NewTagName="Item.Consumable.Crops")
 NumBitsForContainerSize=6
 NetIndexFirstBitSegment=16
++GameplayTagList=(Tag="Als.LocomotionAction.Mounted",DevComment="")
 +GameplayTagList=(Tag="Als.OverlayMode.Axe",DevComment="")
 +GameplayTagList=(Tag="Als.OverlayMode.Axe.Iron",DevComment="")
 +GameplayTagList=(Tag="Als.OverlayMode.Axe.Stone",DevComment="")

--- a/Content/Characters/RobotParts/AO/Attacking_Skeleton.uasset
+++ b/Content/Characters/RobotParts/AO/Attacking_Skeleton.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0bf6152337482843ad26390036fa7530b53200f3f7a8b27cbbc9e4ba83f4a1c0
-size 15212
+oid sha256:fd0d61855bfebc2edc2028a47b2b4b7ed9da0ac889736b43c461101dd2b209f0
+size 15576

--- a/Plugins/ALS-Refactored-4.15/Content/ALS/Character/AnimationInstances/AB_Als_Mounted.uasset
+++ b/Plugins/ALS-Refactored-4.15/Content/ALS/Character/AnimationInstances/AB_Als_Mounted.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:76805e9f6310873e26919be00800b7b60358afa0b171516794e6d0afe6409d4f
-size 92764
+oid sha256:9d51efb2ca9ef70c023154d27fd98e5d6791170e3b2d7dac15ef23f42fdc0337
+size 92791

--- a/Source/CR4S/Character/Characters/ModularRobot.h
+++ b/Source/CR4S/Character/Characters/ModularRobot.h
@@ -242,6 +242,7 @@ private:
 protected:
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly)
 	TObjectPtr<APlayerCharacter> MountedCharacter;
+	
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly)
 	FTimerHandle DashCooldownTimerHandle;
 

--- a/Source/CR4S/Character/Characters/PlayerCharacter.cpp
+++ b/Source/CR4S/Character/Characters/PlayerCharacter.cpp
@@ -115,7 +115,7 @@ void APlayerCharacter::OnDeath()
 	if (!CR4S_ENSURE(LogHong1,InputSubsystem)) return;
 
 	InputSubsystem->RemoveMappingContext(InputMappingContext);
-	SetOverlayMode(AlsOverlayModeTags::Default);
+	//SetOverlayMode(AlsOverlayModeTags::Default);
 	StartRagdolling();
 	Status->StopConsumeHunger();
 }
@@ -327,7 +327,6 @@ void APlayerCharacter::PossessedBy(AController* NewController)
 {
 	Super::PossessedBy(NewController);
 	
-	SetOverlayMode(AlsOverlayModeTags::Default);
 
 	Interaction->InitComponent();
 	Interaction->StartDetectProcess();
@@ -349,7 +348,6 @@ void APlayerCharacter::UnPossessed()
 		}
 	}
 	
-	SetOverlayMode(OverlayMode::Mounted);
 	DisconnectWidgets();
 	Status->SetIsUnPossessed(true);
 

--- a/Source/CR4S/Character/Data/RobotSettings.h
+++ b/Source/CR4S/Character/Data/RobotSettings.h
@@ -25,7 +25,9 @@ public:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Mount")
 	float UnMountOffset {-200};
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Mount")
-	FName MountSocketName {FName("cockpit")};
+	FName StandingMountSocketName {FName("standing")};
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Mount")
+	FName CrouchingMountSocketName {FName("crouching")};
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Mount")
 	int32 CollisionCheckCount{8};
 	

--- a/Source/CR4S/Utility/Cr4sGameplayTags.cpp
+++ b/Source/CR4S/Utility/Cr4sGameplayTags.cpp
@@ -37,9 +37,9 @@ namespace ToolTags
 	UE_DEFINE_GAMEPLAY_TAG(Hammer,FName(TEXT("Als.OverlayMode.Hammer")));
 }
 
-namespace OverlayMode
+namespace CustomLocomotionAction
 {
-	UE_DEFINE_GAMEPLAY_TAG(Mounted,FName(TEXT("Als.OverlayMode.Mounted")));
+	UE_DEFINE_GAMEPLAY_TAG(Mounted,FName(TEXT("Als.LocomotionAction.Mounted")));
 }
 
 namespace RobotParts

--- a/Source/CR4S/Utility/Cr4sGameplayTags.h
+++ b/Source/CR4S/Utility/Cr4sGameplayTags.h
@@ -37,7 +37,7 @@ namespace ToolTags
 	CR4S_API UE_DECLARE_GAMEPLAY_TAG_EXTERN(Hammer);
 }
 
-namespace OverlayMode
+namespace CustomLocomotionAction
 {
 	CR4S_API UE_DECLARE_GAMEPLAY_TAG_EXTERN(Mounted);
 }


### PR DESCRIPTION
# 앉은 상태에서 로봇 탑승시 이상한 위치로 부착되는 에러
- 앉은 상태에서는 콜리전 크기가 줄어듦 -> 이로 인해 콜리전 중심 위치가 변동되어 이상한 위치로 부착
- 서 있을 때와 앉았을 때의 소켓 부착 위치를 2개로 분할
- 각각의 상태에 따라 알맞은 소켓에 부착하도록 로직 변경